### PR TITLE
Document config source boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Runtime profile
+CERUL_ENV=development
+
+# Private runtime / secrets
 # Database
 DATABASE_URL=
 
@@ -19,18 +23,16 @@ YOUTUBE_API_KEY=
 # Stripe
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
+
+# Provider-managed runtime values
 STRIPE_PRO_PRICE_ID=
 
-# App URLs
-API_BASE_URL=http://localhost:8000
-WEB_BASE_URL=http://localhost:3000
-
-# Runtime
-CERUL_ENV=dev
-
-# Search tuning
-MMR_LAMBDA=0.75
-SCENE_THRESHOLD=0.35
-KNOWLEDGE_RERANK_TOP_N=20
+# Optional overrides for values that normally live in config/*.yaml.
+# Leave blank unless you need an env-specific override.
+API_BASE_URL=
+WEB_BASE_URL=
+MMR_LAMBDA=
+SCENE_THRESHOLD=
+KNOWLEDGE_RERANK_TOP_N=
 CLIP_SCORE_THRESHOLD=
 RERANK_PROMPT=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Do not commit:
 If material is useful internally but not suitable for the repository, keep it under the local private workspace rather than adding it here.
 
 ## Project Structure & Module Organization
-Cerul is organized as a lightweight monorepo with root-level product entrypoints. Put the Next.js app in `frontend/` (`app/`, `components/`, `lib/`) and the FastAPI app in `backend/` (`app/routers`, `app/services`, `app/middleware`). Backend domain modules live under `backend/app/` (`auth/`, `billing/`, `db/`, `embedding/`, `search/`, `telemetry/`). Shared pipeline infrastructure belongs in `workers/common/pipeline`, while track-specific indexing flows live in `workers/broll` and `workers/knowledge`. Keep public-safe docs in `docs/`, migrations and seed data in `db/`, installable agent skills in `skills/`, config files in `config/`, and local automation scripts in `scripts/`.
+Cerul is organized as a lightweight monorepo with root-level product entrypoints. Put the Next.js app in `frontend/` (`app/`, `components/`, `lib/`) and the FastAPI app in `backend/` (`app/routers`, `app/services`, `app/middleware`). Backend domain modules live under `backend/app/` (`auth/`, `billing/`, `db/`, `embedding/`, `search/`, `telemetry/`). Shared pipeline infrastructure belongs in `workers/common/pipeline`, while track-specific indexing flows live in `workers/broll` and `workers/knowledge`. Keep public-safe docs in `docs/`, migrations and seed data in `db/`, installable agent skills in `skills/`, public-safe config files in `config/`, and local automation scripts in `scripts/`.
 
 Do not create a top-level `sdk/` just to wrap Cerul's own backend calls. An SDK only belongs in the repo once there is a real public client package to ship and version independently. Until then, frontend code should call backend APIs directly, and agent integrations should prefer a documented skill plus direct HTTP access. Treat MCP the same way: it is a future adapter, not a required first-class module in the initial repository layout.
 
@@ -84,7 +84,7 @@ This repository is still scaffold-first: no root `package.json`, `pyproject.toml
 cp .env.example .env
 ```
 
-Use it to seed local secrets and service URLs before running any new app code. When you add runnable modules, expose explicit commands close to that module and document them in both `README.md` and this file (for example, `pnpm --dir frontend dev` or `pytest backend`).
+Use it to seed local secrets, runtime profile selection, and any optional env overrides before running new app code. Public-safe default config should live in `config/*.yaml`, not in `.env`. Frontend browser code must consume a derived public config subset rather than reading raw repo config files directly. When you add runnable modules, expose explicit commands close to that module and document them in both `README.md` and this file (for example, `pnpm --dir frontend dev` or `pytest backend`).
 
 ## Coding Style & Naming Conventions
 Match the target stack. Use `snake_case` for Python modules, functions, and worker steps (`knowledge`, `scene_threshold`), and `PascalCase` for React components with `camelCase` helpers. Prefer 4-space indentation in Python and 2 spaces in TypeScript, JSON, and YAML. Keep files narrowly scoped: API routing stays in `backend/app/routers`, shared retrieval logic stays in `backend/app/search`, pipeline primitives stay in `workers/common/pipeline`, and app-only utilities stay inside the owning app.
@@ -220,6 +220,6 @@ Issue rules:
 - include acceptance criteria when the task is implementation-driven
 
 ## Security & Configuration Tips
-Never commit `.env`, provider credentials, or generated artifacts. Use `.env.example` as the source of truth for required variables such as `OPENAI_API_KEY`, `DATABASE_URL`, and content API keys.
+Never commit `.env`, provider credentials, or generated artifacts. Use `.env.example` as the source of truth for required private variables such as `OPENAI_API_KEY`, `DATABASE_URL`, and content API keys. Use `config/*.yaml` for commit-safe defaults and non-sensitive tuning values. Treat `publicConfig` as a code-level whitelist derived from those sources, not as a third configuration store.
 
 If a change affects public docs or repository metadata, ensure the result still matches the intended open-source boundary of the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ workers/      Indexing pipelines and ingestion workers
 docs/         Public project docs
 db/           Migrations and public-safe seeds
 skills/       Installable agent skills
-config/       Config files
+config/       Public-safe config defaults
 scripts/      Local scripts and bootstrap helpers
 ```
 
@@ -122,6 +122,8 @@ Do not commit:
 - internal fundraising or strategy materials
 
 If a file is useful internally but should not be public, keep it out of this repository.
+
+Public-safe runtime defaults belong in `config/`. Secrets and provider credentials belong in `.env` or deployment platform env vars.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ workers/      Indexing pipelines and job workers
 docs/         Public architecture, API, product, and runbook docs
 db/           Migrations and public-safe seed data
 skills/       Installable agent skills for Codex / Claude-style clients
-config/       YAML config files
+config/       Public-safe YAML config defaults and templates
 scripts/      Bootstrap and local utility scripts
 ```
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,11 +1,39 @@
 # Config Workspace
 
-This directory is reserved for public-safe configuration templates.
+This directory holds versioned, public-safe runtime config for Cerul.
 
-Use it for:
+Rules:
 
-- local development config examples
-- YAML templates that are safe to publish
-- environment-specific sample config files
+- commit only values that are safe to publish
+- keep secrets in the root `.env` file or deployment platform env vars
+- prefer structured config files here over growing `.env` with non-secret tuning knobs
+- treat env vars as overrides, not the primary store for application behavior
 
-Do not commit real secrets or production credentials here.
+Recommended files:
+
+- `base.yaml` for shared defaults
+- `development.yaml` for local-safe overrides
+- `production.yaml` for public production-safe overrides
+
+Consumption model:
+
+- backend and workers load `base.yaml` + one environment file + env overrides
+- frontend server code should read only a whitelisted public subset
+- `publicConfig` is a derived code-level export from `config/*.yaml` + env, not a separate source of truth
+- browser code must not read raw files from this directory directly
+- if `frontend/` is deployed from a subdirectory, generate or copy a public config artifact during build instead of assuming runtime filesystem access to the repo root
+
+Safe candidates for this directory:
+
+- search thresholds and ranking defaults
+- enabled tracks and demo defaults
+- public URLs and non-secret feature flags
+- prompt template identifiers, but not private tuned prompt bodies
+
+Do not put these here:
+
+- API keys
+- database passwords
+- auth secrets
+- webhook signing secrets
+- proprietary production prompt contents

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -1,0 +1,16 @@
+version: 1
+
+public:
+  default_track: broll
+  enabled_tracks:
+    - broll
+    - knowledge
+
+search:
+  mmr_lambda: 0.75
+  clip_score_threshold: null
+
+knowledge:
+  scene_threshold: 0.35
+  rerank_top_n: 20
+  rerank_prompt_template: default

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,0 +1,5 @@
+public:
+  app_env: development
+  api_base_url: http://localhost:8000
+  web_base_url: http://localhost:3000
+  demo_mode: true

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,0 +1,5 @@
+public:
+  app_env: production
+  api_base_url: https://api.cerul.ai
+  web_base_url: https://cerul.ai
+  demo_mode: false


### PR DESCRIPTION
## Summary
- clarify the repository rule that `config/` stores public-safe structured defaults while `.env` stores secrets and deployment overrides
- document that frontend browser code must use a derived `publicConfig` whitelist instead of reading raw repo config files
- add initial `config/base.yaml`, `config/development.yaml`, and `config/production.yaml` templates

## Affected Directories
- `config/`
- repository docs (`README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `.env.example`)

## Env Vars / Configuration Changes
- reframe `.env.example` so `CERUL_ENV` selects the runtime profile and non-sensitive tuning values are optional overrides
- introduce versioned config templates under `config/` for commit-safe defaults

## Testing Status
- not run; documentation and config template changes only