### PR TITLE
Polish docs experience and harden demo routes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,314 @@
+# Cerul API Reference
+
+Video understanding search API for AI agents. Search what is shown in videos, not just what is said.
+
+## Base URL
+
+```
+https://api.cerul.ai
+```
+
+## Authentication
+
+All API requests must include your API key in the Authorization header using the Bearer token format:
+
+```bash
+curl "https://api.cerul.ai/v1/search" \
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+Get your API key from the [Cerul Dashboard](https://cerul.ai/dashboard).
+
+---
+
+## Search API
+
+### POST /v1/search
+
+Search for video content using semantic queries. Returns matching videos with direct URLs.
+
+#### Request
+
+```bash
+curl "https://api.cerul.ai/v1/search" \
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "cinematic drone shot of coastal highway at sunset",
+    "search_type": "broll",
+    "max_results": 5,
+    "filters": {
+      "min_duration": 5,
+      "max_duration": 30
+    }
+  }'
+```
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query describing the video content you want |
+| `search_type` | string | Yes | Either `"broll"` (stock footage) or `"knowledge"` (educational content) |
+| `max_results` | integer | No | Number of results to return (1-50, default: 10) |
+| `include_answer` | boolean | No | Include AI-generated summary for knowledge searches |
+| `filters` | object | No | Additional filters based on search type |
+
+#### B-roll Filters
+
+```json
+{
+  "min_duration": 5,        // Minimum video length in seconds
+  "max_duration": 60,       // Maximum video length in seconds
+  "source": "pexels"        // Filter by source (pexels, pixabay)
+}
+```
+
+#### Knowledge Filters
+
+```json
+{
+  "speaker": "Sam Altman",       // Filter by speaker name
+  "published_after": "2023-01-01" // Filter by publication date
+}
+```
+
+#### Response
+
+```json
+{
+  "results": [
+    {
+      "id": "pexels_28192743",
+      "score": 0.94,
+      "title": "Aerial drone shot of coastal highway",
+      "description": "Cinematic 4K drone footage of winding coastal road at golden hour with ocean views",
+      "video_url": "https://videos.pexels.com/video-files/28192743/aerial-coastal-drone.mp4",
+      "thumbnail_url": "https://images.pexels.com/photos/28192743/pexels-photo-28192743.jpeg",
+      "duration": 18,
+      "source": "pexels",
+      "license": "pexels-license"
+    }
+  ],
+  "credits_used": 1,
+  "credits_remaining": 999,
+  "request_id": "req_abc123xyz"
+}
+```
+
+#### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier for the result |
+| `score` | float | Relevance score (0.0-1.0) |
+| `title` | string | Video title |
+| `description` | string | Video description |
+| `video_url` | string | **Direct URL to the MP4 file** (valid for 24 hours) |
+| `thumbnail_url` | string | URL to preview image |
+| `duration` | integer | Video length in seconds |
+| `source` | string | Content source (pexels, pixabay, youtube) |
+| `license` | string | License type for usage rights |
+
+**Knowledge-specific fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp_start` | float | Start time in seconds (for knowledge) |
+| `timestamp_end` | float | End time in seconds (for knowledge) |
+| `answer` | string | AI-generated summary (if `include_answer: true`) |
+
+---
+
+## Usage API
+
+### GET /v1/usage
+
+Check your current credit balance and usage statistics.
+
+#### Request
+
+```bash
+curl "https://api.cerul.ai/v1/usage" \
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY"
+```
+
+#### Response
+
+```json
+{
+  "tier": "free",
+  "period_start": "2026-03-01",
+  "period_end": "2026-03-31",
+  "credits_limit": 1000,
+  "credits_used": 128,
+  "credits_remaining": 872,
+  "rate_limit_per_sec": 1,
+  "api_keys_active": 1
+}
+```
+
+---
+
+## Code Examples
+
+### Python
+
+```python
+import requests
+
+API_KEY = "YOUR_CERUL_API_KEY"
+BASE_URL = "https://api.cerul.ai"
+
+# Search for b-roll footage
+response = requests.post(
+    f"{BASE_URL}/v1/search",
+    headers={
+        "Authorization": f"Bearer {API_KEY}",
+        "Content-Type": "application/json"
+    },
+    json={
+        "query": "business handshake in modern office",
+        "search_type": "broll",
+        "max_results": 5
+    }
+)
+
+data = response.json()
+
+# Get the first video URL
+if data["results"]:
+    video_url = data["results"][0]["video_url"]
+    print(f"Video URL: {video_url}")
+```
+
+### JavaScript/Node.js
+
+```javascript
+const API_KEY = 'YOUR_CERUL_API_KEY';
+const BASE_URL = 'https://api.cerul.ai';
+
+async function searchVideos(query, searchType = 'broll') {
+  const response = await fetch(`${BASE_URL}/v1/search`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      query,
+      search_type: searchType,
+      max_results: 5
+    })
+  });
+
+  const data = await response.json();
+  return data.results;
+}
+
+// Usage
+searchVideos('cinematic drone shot', 'broll')
+  .then(results => {
+    results.forEach(video => {
+      console.log(`${video.title}: ${video.video_url}`);
+    });
+  });
+```
+
+### Using with OpenAI SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.cerul.ai/v1",
+    api_key="YOUR_CERUL_API_KEY"
+)
+
+response = client.chat.completions.create(
+    model="cerul-broll",
+    messages=[{
+        "role": "user",
+        "content": "cinematic drone shot of coastal highway"
+    }]
+)
+
+print(response.choices[0].message.content)
+```
+
+---
+
+## Error Handling
+
+The API uses standard HTTP status codes:
+
+| Status | Description |
+|--------|-------------|
+| `200 OK` | Request successful |
+| `400 Bad Request` | Invalid request parameters |
+| `401 Unauthorized` | Missing or invalid API key |
+| `429 Too Many Requests` | Rate limit exceeded |
+| `500 Internal Server Error` | Server error (rare) |
+
+Error response format:
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "Missing required field: query"
+  }
+}
+```
+
+---
+
+## Rate Limits
+
+| Tier | Requests/second | Monthly Credits |
+|------|-----------------|-----------------|
+| Free | 1 | 1,000 |
+| Builder ($20/mo) | 10 | 10,000 |
+| Enterprise | Custom | Custom |
+
+Rate limit headers are included in all responses:
+
+```
+X-RateLimit-Limit: 10
+X-RateLimit-Remaining: 9
+X-RateLimit-Reset: 1709856000
+```
+
+---
+
+## Pricing
+
+### Free Tier
+- **$0/month**
+- 1,000 credits
+- 1 request/second
+- Community support
+
+### Builder Tier
+- **$20/month**
+- 10,000 credits
+- 10 requests/second
+- Priority support
+- Usage analytics
+
+### Enterprise
+- Custom pricing
+- Unlimited credits
+- Custom rate limits
+- SLA guarantee
+- Dedicated support
+
+---
+
+## Support
+
+- Documentation: https://cerul.ai/docs
+- Dashboard: https://cerul.ai/dashboard
+- GitHub: https://github.com/JessyTsui/cerul
+- Email: team@cerul.ai

--- a/frontend/app/api/demo/search/route.ts
+++ b/frontend/app/api/demo/search/route.ts
@@ -1,16 +1,26 @@
 import { NextResponse } from "next/server";
-import { simulateDemoSearch } from "@/lib/demo-api";
-import type { DemoMode } from "@/lib/demo-api";
-
-type SearchRequestBody = {
-  mode?: DemoMode;
-  query?: string;
-};
+import { simulateDemoSearch, validateDemoSearchRequestBody } from "@/lib/demo-api";
 
 export async function POST(request: Request) {
-  const body = (await request.json()) as SearchRequestBody;
-  const mode = body.mode ?? "knowledge";
-  const query = body.query ?? "";
+  let body: unknown;
 
-  return NextResponse.json(simulateDemoSearch({ mode, query }));
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body." },
+      { status: 400 },
+    );
+  }
+
+  const validation = validateDemoSearchRequestBody(body);
+
+  if (!validation.ok) {
+    return NextResponse.json(
+      { error: validation.error },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json(simulateDemoSearch(validation.value));
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -22,8 +22,8 @@ export default function DashboardPage() {
   return (
     <DashboardShell
       currentPath="/dashboard"
-      title="Operate keys, usage, and indexing jobs."
-      description="The console is organized around operator workflows: inspect credit health, understand search traffic, and monitor pipeline throughput without leaking backend logic into the frontend."
+      title="Dashboard"
+      description="Operate keys, usage, and indexing jobs."
       snapshot={snapshot}
       actions={
         <>
@@ -31,158 +31,161 @@ export default function DashboardPage() {
             API docs
           </Link>
           <a className="button-primary" href="mailto:team@cerul.ai">
-            Request enterprise access
+            Contact sales
           </a>
         </>
       }
     >
-      <section className="grid gap-4 lg:grid-cols-4">
+      {/* Overview cards */}
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {snapshot.overviewCards.map((item) => (
           <article key={item.label} className="surface px-5 py-5">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
+            <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
               {item.label}
             </p>
-            <p className="mt-4 text-3xl font-semibold tracking-tight">{item.value}</p>
-            <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{item.caption}</p>
+            <p className="mt-3 text-2xl font-bold text-white">{item.value}</p>
+            <p className="mt-1 text-sm text-[var(--foreground-tertiary)]">{item.caption}</p>
           </article>
         ))}
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-        <article className="surface px-6 py-6">
+      {/* Charts */}
+      <section className="grid gap-5 lg:grid-cols-[1.1fr_0.9fr]">
+        <article className="surface-elevated px-6 py-6">
           <div className="flex items-center justify-between gap-4">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
+              <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
                 Monthly request mix
               </p>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight">
+              <h2 className="mt-2 text-xl font-bold text-white">
                 Search volume by track
               </h2>
             </div>
-            <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--accent)]">
+            <span className={`badge ${
+              snapshot.liveStatus.health === "Healthy"
+                ? "badge-success"
+                : snapshot.liveStatus.health === "Degraded"
+                ? "badge-warning"
+                : "badge-error"
+            }`}>
               {snapshot.liveStatus.health}
             </span>
           </div>
-          <div className="mt-8 space-y-5">
+          <div className="mt-6 space-y-4">
             {snapshot.searchMix.map((item) => (
               <div
                 key={item.label}
-                className="grid gap-2 sm:grid-cols-[160px_1fr_auto] sm:items-center"
+                className="grid gap-2 sm:grid-cols-[140px_1fr_auto] sm:items-center"
               >
-                <p className="text-sm font-medium">{item.label}</p>
-                <div className="chart-bar h-3">
+                <p className="text-sm font-medium text-white">{item.label}</p>
+                <div className="chart-bar">
                   <span style={{ width: `${item.value}%` }} />
                 </div>
-                <p className="font-mono text-xs text-[var(--brand-deep)]">{item.value}%</p>
+                <p className="font-mono text-xs text-[var(--brand-bright)]">{item.value}%</p>
               </div>
             ))}
           </div>
         </article>
 
-        <article className="surface px-6 py-6">
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-            Worker state
+        <article className="surface-elevated px-6 py-6">
+          <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+            Pipeline state
           </p>
-          <h2 className="mt-3 text-2xl font-semibold tracking-tight">
-            Pipeline health
+          <h2 className="mt-2 text-xl font-bold text-white">
+            Worker health
           </h2>
-          <div className="mt-6 space-y-4">
+          <div className="mt-5 space-y-3">
             {snapshot.pipelineRuns.slice(0, 3).map((run) => (
               <div
                 key={run.id}
-                className="rounded-[22px] border border-[var(--line)] bg-white/72 px-4 py-4"
+                className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-4"
               >
                 <div className="flex items-center justify-between gap-3">
                   <div>
-                    <p className="font-medium">{run.source}</p>
-                    <p className="mt-1 text-sm text-[var(--muted)]">{run.stage}</p>
+                    <p className="font-medium text-white">{run.source}</p>
+                    <p className="text-sm text-[var(--foreground-tertiary)]">{run.stage}</p>
                   </div>
-                  <p className="text-2xl font-semibold tracking-tight">{run.progress}%</p>
+                  <p className="text-xl font-bold text-white">{run.progress}%</p>
                 </div>
-                <div className="chart-bar mt-4 h-3">
+                <div className="chart-bar mt-3">
                   <span style={{ width: `${run.progress}%` }} />
                 </div>
-                <p className="mt-3 text-sm leading-6 text-[var(--muted)]">{run.note}</p>
+                <p className="mt-2 text-sm text-[var(--foreground-tertiary)]">{run.note}</p>
               </div>
             ))}
           </div>
         </article>
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-[0.95fr_1.05fr]">
-        <article className="surface px-6 py-6">
+      {/* API Keys + Recent queries */}
+      <section className="grid gap-5 lg:grid-cols-2">
+        <article className="surface-elevated px-6 py-6">
           <div className="flex items-center justify-between gap-4">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
+              <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
                 API keys
               </p>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight">
+              <h2 className="mt-2 text-xl font-bold text-white">
                 Access management
               </h2>
             </div>
-            <Link href="/dashboard/keys" className="button-secondary">
-              Manage keys
+            <Link href="/dashboard/keys" className="button-secondary text-sm">
+              Manage
             </Link>
           </div>
-          <div className="mt-6 space-y-3">
+          <div className="mt-5 space-y-3">
             {snapshot.apiKeys.map((key) => (
               <div
                 key={key.name}
-                className="rounded-[22px] border border-[var(--line)] bg-white/72 px-4 py-4"
+                className="flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3"
               >
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <p className="font-medium">{key.name}</p>
-                    <p className="mt-1 font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
-                      {key.prefix}
-                    </p>
-                  </div>
+                <div>
+                  <p className="font-medium text-white">{key.name}</p>
+                  <p className="font-mono text-xs text-[var(--foreground-tertiary)]">
+                    {key.prefix}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3">
                   <span
-                    className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    className={`rounded-full px-2.5 py-1 text-xs font-medium ${
                       key.status === "Active"
-                        ? "bg-emerald-100 text-emerald-700"
-                        : "bg-slate-200 text-slate-700"
+                        ? "bg-emerald-500/15 text-emerald-400"
+                        : "bg-[var(--surface-elevated)] text-[var(--foreground-tertiary)]"
                     }`}
                   >
                     {key.status}
                   </span>
                 </div>
-                <div className="mt-3 grid grid-cols-2 gap-3 text-sm text-[var(--muted)]">
-                  <span>{key.scope}</span>
-                  <span className="text-right">{key.lastUsed}</span>
-                </div>
               </div>
             ))}
           </div>
         </article>
 
-        <article className="surface px-6 py-6">
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-            Recent query runs
+        <article className="surface-elevated px-6 py-6">
+          <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+            Recent queries
           </p>
-          <h2 className="mt-3 text-2xl font-semibold tracking-tight">
-            Search traffic snapshot
+          <h2 className="mt-2 text-xl font-bold text-white">
+            Search traffic
           </h2>
-          <div className="mt-6 overflow-hidden rounded-[24px] border border-[var(--line)]">
-            <table className="min-w-full border-collapse text-left text-sm">
-              <thead className="bg-white/86">
+          <div className="mt-5 overflow-hidden rounded-lg border border-[var(--border)]">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-[var(--surface)]">
                 <tr>
-                  <th className="px-4 py-3 font-medium">Query</th>
-                  <th className="px-4 py-3 font-medium">Track</th>
-                  <th className="px-4 py-3 font-medium">Latency</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium text-[var(--foreground-secondary)]">Query</th>
+                  <th className="px-4 py-3 font-medium text-[var(--foreground-secondary)]">Track</th>
+                  <th className="px-4 py-3 font-medium text-[var(--foreground-secondary)]">Status</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="divide-y divide-[var(--border)]">
                 {snapshot.recentQueries.map((run) => (
-                  <tr key={run.query} className="border-t border-[var(--line)] bg-white/72">
-                    <td className="px-4 py-3">{run.query}</td>
-                    <td className="px-4 py-3 font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
+                  <tr key={run.query} className="bg-[var(--background-elevated)]">
+                    <td className="max-w-[200px] truncate px-4 py-3 text-white">{run.query}</td>
+                    <td className="px-4 py-3 font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
                       {run.track}
                     </td>
-                    <td className="px-4 py-3">{run.latency}</td>
                     <td className="px-4 py-3">
-                      <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                      <span className="rounded-full bg-emerald-500/15 px-2.5 py-1 text-xs font-medium text-emerald-400">
                         {run.status}
                       </span>
                     </td>

--- a/frontend/app/docs/[slug]/page.tsx
+++ b/frontend/app/docs/[slug]/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { AIToolbar } from "@/components/ai-toolbar";
 import { DocsSidebar } from "@/components/docs-sidebar";
-import { SiteFooter } from "@/components/site-footer";
+import { DocsToc, type TocItem } from "@/components/docs-toc";
+import { CodeBlock } from "@/components/code-block";
 import { SiteHeader } from "@/components/site-header";
 import {
   getDocBySlug,
@@ -47,92 +49,156 @@ export default async function DocDetailPage({ params }: DocPageProps) {
     notFound();
   }
 
-  const anchors = page.sections.map((section, index) => ({
-    href: `#section-${index + 1}`,
-    label: section.title,
-    index: `${index + 1}`.padStart(2, "0"),
-  }));
+  const tocItems: TocItem[] = [
+    { id: "intro", text: page.title, level: 1 },
+    ...page.sections.map((section, index) => ({
+      id: `section-${index + 1}`,
+      text: section.title,
+      level: 1,
+    })),
+  ];
 
   return (
-    <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col px-5 pb-8 pt-5 sm:px-8 lg:px-10">
+    <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
       <SiteHeader currentPath={`/docs/${slug}`} />
-      <main className="flex-1 pb-12 pt-10">
-        <section className="surface px-6 py-7 sm:px-8">
-          <div className="grid gap-8 lg:grid-cols-[0.92fr_1.08fr] lg:items-end">
-            <div>
-              <span className="label">{page.kicker}</span>
-              <h1 className="display-title mt-5 text-5xl sm:text-6xl">{page.title}</h1>
-            </div>
-            <div>
-              <p className="text-lg leading-8 text-[var(--muted)]">{page.summary}</p>
-              <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-                <span className="rounded-full border border-[var(--line)] bg-white/72 px-4 py-2 font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
-                  {page.readingTime}
-                </span>
-                <Link href="/docs" className="button-secondary">
-                  Back to docs
-                </Link>
-              </div>
-            </div>
-          </div>
-        </section>
 
-        <section className="grid gap-6 pt-10 lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start">
-          <DocsSidebar currentSlug={slug} anchors={anchors} />
-          <div className="space-y-6">
+      <div className="mt-8 grid gap-8 lg:grid-cols-[280px_1fr_200px]">
+        {/* Left sidebar */}
+        <DocsSidebar currentSlug={slug} />
+
+        {/* Main content */}
+        <main className="min-w-0" data-ai-copy-root="true">
+          {/* Header */}
+          <div id="intro" className="mb-10 scroll-mt-24">
+            <section className="surface-elevated relative overflow-hidden px-6 py-7 sm:px-8">
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[var(--brand)] to-transparent opacity-80" />
+              <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_240px]">
+                <div>
+                  <p className="eyebrow">{page.kicker}</p>
+                  <h1 className="mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+                    {page.title}
+                  </h1>
+                  <p className="mt-4 max-w-2xl text-lg leading-8 text-[var(--foreground-secondary)]">
+                    {page.summary}
+                  </p>
+
+                  <div className="mt-5 flex flex-wrap items-center gap-3">
+                    <span className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-3 py-1 font-mono text-xs text-[var(--foreground-tertiary)]">
+                      {page.readingTime}
+                    </span>
+                    <span className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-3 py-1 font-mono text-xs text-[var(--foreground-tertiary)]">
+                      {page.sections.length} sections
+                    </span>
+                    <Link href="/docs" className="text-sm text-[var(--brand-bright)] hover:underline">
+                      ← Back to docs
+                    </Link>
+                  </div>
+
+                  <div className="mt-6">
+                    <AIToolbar
+                      copyRootSelector="[data-ai-copy-root='true']"
+                      pageUrl={`/docs/${slug}`}
+                      pageTitle={page.title}
+                    />
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+                  <div className="rounded-[18px] border border-[var(--border)] bg-[var(--surface)] px-4 py-4">
+                    <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--brand-bright)]">
+                      Guide
+                    </p>
+                    <p className="mt-3 text-xl font-semibold text-white">{page.kicker}</p>
+                    <p className="mt-2 text-sm leading-6 text-[var(--foreground-secondary)]">
+                      Built to be operator-readable before you wire in automation.
+                    </p>
+                  </div>
+                  <div className="rounded-[18px] border border-[var(--border)] bg-[var(--surface)] px-4 py-4">
+                    <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--brand-bright)]">
+                      Read time
+                    </p>
+                    <p className="mt-3 text-xl font-semibold text-white">{page.readingTime}</p>
+                    <p className="mt-2 text-sm leading-6 text-[var(--foreground-secondary)]">
+                      Quick enough for onboarding, specific enough for implementation.
+                    </p>
+                  </div>
+                  <div className="rounded-[18px] border border-[var(--border)] bg-[var(--surface)] px-4 py-4">
+                    <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--brand-bright)]">
+                      Focus
+                    </p>
+                    <p className="mt-3 text-xl font-semibold text-white">Practical API use</p>
+                    <p className="mt-2 text-sm leading-6 text-[var(--foreground-secondary)]">
+                      Examples, request shape, and the minimum context needed to ship.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          {/* Sections */}
+          <div className="space-y-12">
             {page.sections.map((section, index) => (
               <section
                 key={section.title}
                 id={`section-${index + 1}`}
-                className="surface scroll-mt-28 px-6 py-6 sm:px-8"
+                className="scroll-mt-24 rounded-[24px] border border-[var(--border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.02))] p-6 sm:p-8"
               >
-                <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--brand-deep)]">
-                  {`${index + 1}`.padStart(2, "0")}
+                <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--brand-bright)] mb-2">
+                  {String(index + 1).padStart(2, "0")}
                 </p>
-                <h2 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
-                  {section.title}
-                </h2>
-                <p className="mt-4 text-base leading-7 text-[var(--muted)]">
-                  {section.body}
-                </p>
+                <h2 className="text-2xl font-bold text-white">{section.title}</h2>
+                <p className="mt-3 max-w-3xl text-[var(--foreground-secondary)]">{section.body}</p>
+
                 {section.bullets?.length ? (
-                  <ul className="mt-6 grid gap-3 sm:grid-cols-2">
+                  <ul className="mt-5 grid gap-3 sm:grid-cols-2">
                     {section.bullets.map((bullet) => (
                       <li
                         key={bullet}
-                        className="rounded-[22px] border border-[var(--line)] bg-white/72 px-4 py-3 text-sm leading-6"
+                        className="flex items-start gap-2 rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground-secondary)]"
                       >
+                        <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[var(--brand)]" />
                         {bullet}
                       </li>
                     ))}
                   </ul>
                 ) : null}
+
                 {section.code ? (
-                  <div className="code-window mt-7 px-5 py-5 sm:px-6">
-                    <pre>{section.code}</pre>
+                  <div className="mt-6">
+                    <CodeBlock
+                      code={section.code}
+                      filename={section.filename || "example.sh"}
+                      language={section.language || "bash"}
+                    />
                   </div>
                 ) : null}
               </section>
             ))}
-
-            <section className="surface-strong px-6 py-6 sm:px-8">
-              <p className="eyebrow">Next surface</p>
-              <h2 className="display-title mt-3 text-4xl sm:text-5xl">
-                Inspect how the same contract shows up in the operator console.
-              </h2>
-              <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-                <Link href="/dashboard" className="button-primary">
-                  Open dashboard
-                </Link>
-                <Link href="/pricing" className="button-secondary">
-                  Review pricing
-                </Link>
-              </div>
-            </section>
           </div>
-        </section>
-      </main>
-      <SiteFooter />
+
+          {/* Next steps */}
+          <div className="surface-gradient mt-12 p-6">
+            <h3 className="text-lg font-semibold text-white">Continue Reading</h3>
+            <p className="mt-2 text-[var(--foreground-secondary)]">
+              Explore more guides or try the API in the dashboard.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <Link href="/docs" className="button-secondary">
+                All Guides
+              </Link>
+              <Link href="/dashboard" className="button-primary">
+                Open Dashboard
+              </Link>
+            </div>
+          </div>
+        </main>
+
+        {/* Right TOC */}
+        <div className="hidden lg:block">
+          <DocsToc items={tocItems} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -1,131 +1,394 @@
 import type { Metadata } from "next";
 import type { Route } from "next";
 import Link from "next/link";
+import { AIToolbar } from "@/components/ai-toolbar";
+import { DocsCard, DocsCards } from "@/components/docs-card";
 import { DocsSidebar } from "@/components/docs-sidebar";
-import { SiteFooter } from "@/components/site-footer";
+import { DocsToc } from "@/components/docs-toc";
+import { CodeBlock } from "@/components/code-block";
+import { DocsTabs } from "@/components/docs-tabs";
 import { SiteHeader } from "@/components/site-header";
-import {
-  docsLandingSections,
-  docsNavigation,
-  getDocsIndexCards,
-} from "@/lib/docs";
+import { docsLandingSections, getDocsIndexCards } from "@/lib/docs";
 
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: "Docs",
+  title: "Documentation",
   description: "Cerul API and platform documentation.",
   alternates: {
     canonical: "/docs",
   },
 };
 
+const docsQuickFacts = [
+  {
+    label: "Setup",
+    value: "5 min",
+    caption: "From API key to first search request.",
+  },
+  {
+    label: "Tracks",
+    value: "2",
+    caption: "Knowledge retrieval and b-roll search on one API.",
+  },
+  {
+    label: "Path",
+    value: "HTTP + skill",
+    caption: "Start with direct calls, then package repeatable workflows.",
+  },
+] as const;
+
+function getGuideIcon(slug: string) {
+  switch (slug) {
+    case "quickstart":
+      return (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M5 12h14" />
+          <path d="m12 5 7 7-7 7" />
+        </svg>
+      );
+    case "search-api":
+      return (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="11" cy="11" r="7" />
+          <path d="m21 21-4.3-4.3" />
+        </svg>
+      );
+    case "usage-api":
+      return (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M3 3v18h18" />
+          <path d="m7 14 4-4 3 3 5-7" />
+        </svg>
+      );
+    default:
+      return (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M4 6h16" />
+          <path d="M4 12h16" />
+          <path d="M4 18h10" />
+        </svg>
+      );
+  }
+}
+
 export default function DocsPage() {
   const guides = getDocsIndexCards();
 
+  const tocItems = [
+    { id: "overview", text: "Overview", level: 1 },
+    { id: "quickstart", text: "Quickstart", level: 1 },
+    ...docsLandingSections.map((section) => ({
+      id: section.id,
+      text: section.title,
+      level: 1,
+    })),
+  ];
+
   return (
-    <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col px-5 pb-8 pt-5 sm:px-8 lg:px-10">
+    <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
       <SiteHeader currentPath="/docs" />
-      <main className="flex-1 pb-12 pt-10">
-        <section className="surface px-6 py-7 sm:px-8">
-          <div className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-end">
-            <div className="space-y-4">
-              <span className="label">Documentation</span>
-              <h1 className="display-title text-5xl sm:text-6xl">
-                One public API surface, no extra protocol maze.
-              </h1>
-            </div>
-            <div className="space-y-5">
-              <p className="text-lg leading-8 text-[var(--muted)]">
-                Cerul starts with the smallest stable public contract: search and
-                usage. Heavy processing stays in workers, authentication stays thin,
-                and agent integrations can call the same API surface directly.
-              </p>
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Link href="/" className="button-secondary">
-                  Back to home
-                </Link>
-                <Link href="/dashboard" className="button-primary">
-                  See console
-                </Link>
+
+      <div className="mt-8 grid gap-8 lg:grid-cols-[280px_1fr_200px]">
+        {/* Left sidebar */}
+        <DocsSidebar />
+
+        {/* Main content */}
+        <main className="min-w-0" data-ai-copy-root="true">
+          {/* Hero */}
+          <div id="overview" className="mb-10 scroll-mt-24">
+            <section className="surface-elevated relative overflow-hidden px-6 py-7 sm:px-8">
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[var(--brand)] to-transparent opacity-80" />
+              <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_280px]">
+                <div>
+                  <p className="eyebrow">Documentation</p>
+                  <h1 className="mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+                    Cerul API Documentation
+                  </h1>
+                  <p className="mt-4 max-w-2xl text-lg leading-8 text-[var(--foreground-secondary)]">
+                    Video understanding search API for AI agents. Search what is shown in videos,
+                    not just what is said.
+                  </p>
+                  <div className="mt-6 flex flex-wrap gap-3">
+                    <Link href="/docs/quickstart" className="button-primary">
+                      Start in 5 minutes
+                    </Link>
+                    <Link href="/dashboard" className="button-secondary">
+                      Try the dashboard
+                    </Link>
+                  </div>
+                  <div className="mt-6">
+                    <AIToolbar
+                      copyRootSelector="[data-ai-copy-root='true']"
+                      pageUrl="/docs"
+                      pageTitle="Cerul Documentation"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+                  {docsQuickFacts.map((fact) => (
+                    <div
+                      key={fact.label}
+                      className="rounded-[18px] border border-[var(--border)] bg-[var(--surface)] px-4 py-4"
+                    >
+                      <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--brand-bright)]">
+                        {fact.label}
+                      </p>
+                      <p className="mt-3 text-2xl font-semibold text-white">{fact.value}</p>
+                      <p className="mt-2 text-sm leading-6 text-[var(--foreground-secondary)]">
+                        {fact.caption}
+                      </p>
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
+            </section>
           </div>
-        </section>
 
-        <section className="pt-8">
-          <div className="mb-5 flex items-end justify-between gap-4">
-            <div>
-              <p className="eyebrow">Guide library</p>
-              <h2 className="display-title mt-2 text-4xl sm:text-5xl">
-                Read the contract before you build around it.
-              </h2>
-            </div>
-          </div>
-          <div className="grid gap-4 lg:grid-cols-4">
-            {guides.map((guide) => (
-              <Link
-                key={guide.slug}
-                href={guide.href as Route}
-                className="surface-strong grid-lines px-5 py-5"
-              >
-                <p className="font-mono text-xs uppercase tracking-[0.16em] text-[var(--brand-deep)]">
-                  {guide.kicker}
+          {/* Guide cards */}
+          <div id="quickstart" className="mb-12 scroll-mt-24">
+            <div className="mb-5 flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold text-white">Guides</h2>
+                <p className="mt-2 text-sm text-[var(--foreground-secondary)]">
+                  Start with quick onboarding, then move into request shape, usage, and architecture.
                 </p>
-                <h3 className="mt-3 text-2xl font-semibold tracking-tight">
-                  {guide.title}
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-                  {guide.summary}
-                </p>
-                <p className="mt-5 font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
-                  {guide.readingTime}
-                </p>
+              </div>
+              <Link href="/docs/search-api" className="text-sm font-medium text-[var(--brand-bright)] transition hover:text-white">
+                See full search reference
               </Link>
-            ))}
+            </div>
+            <DocsCards>
+              {guides.map((guide) => (
+                <DocsCard
+                  key={guide.slug}
+                  title={guide.title}
+                  description={guide.summary}
+                  href={guide.href as Route}
+                  icon={getGuideIcon(guide.slug)}
+                  kicker={guide.kicker}
+                  readingTime={guide.readingTime}
+                />
+              ))}
+            </DocsCards>
           </div>
-        </section>
 
-        <section className="grid gap-6 pt-10 lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start">
-          <DocsSidebar anchors={docsNavigation.map((item) => ({ ...item }))} />
+          {/* Code example with tabs - Two search types */}
+          <div className="mb-12">
+            <div className="mb-5">
+              <h2 className="text-xl font-semibold text-white">Quick Example</h2>
+              <p className="mt-2 text-sm text-[var(--foreground-secondary)]">
+                The primary workflow is request in, evidence-rich results out. Use these samples as your first smoke test.
+              </p>
+            </div>
 
-          <div className="space-y-6">
+            {/* Knowledge Search - Primary */}
+            <div className="mb-6 overflow-hidden rounded-[24px] border border-[var(--border)] bg-[var(--background-elevated)]">
+              <div className="flex flex-wrap items-center gap-2 border-b border-[var(--border-brand)] bg-[var(--brand-subtle)] px-4 py-3">
+                <span className="rounded-full border border-[var(--border-brand)] px-2 py-1 text-[11px] font-semibold tracking-[0.16em] text-[var(--brand-bright)]">
+                  KNOWLEDGE SEARCH
+                </span>
+                <span className="text-xs text-[var(--foreground-secondary)]">Find insights from interviews and talks</span>
+              </div>
+              <DocsTabs
+                items={[
+                  {
+                    label: "cURL",
+                    value: "curl",
+                    content: (
+                      <CodeBlock
+                        filename="knowledge-search.sh"
+                        code={`curl "https://api.cerul.ai/v1/search" \\
+  -H "Authorization: Bearer $CERUL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "Sam Altman views on AI video generation tools",
+    "search_type": "knowledge",
+    "max_results": 3,
+    "include_answer": true
+  }'`}
+                      />
+                    ),
+                  },
+                  {
+                    label: "Response",
+                    value: "response",
+                    content: (
+                      <CodeBlock
+                        filename="knowledge-response.json"
+                        language="json"
+                        code={`{
+  "results": [
+    {
+      "id": "yt_hmtuvNfytjM_1223",
+      "score": 0.96,
+      "title": "Sam Altman on the Future of AI Creative Tools",
+      "video_url": "https://www.youtube.com/watch?v=hmtuvNfytjM&t=1223s",
+      "thumbnail_url": "https://i.ytimg.com/vi/hmtuvNfytjM/hqdefault.jpg",
+      "source": "youtube",
+      "speaker": "Sam Altman",
+      "timestamp_start": 1223,
+      "timestamp_end": 1345,
+      "answer": "Altman believes AI video generation will democratize filmmaking..."
+    }
+  ],
+  "credits_used": 2,
+  "credits_remaining": 998
+}`}
+                      />
+                    ),
+                  },
+                ]}
+              />
+            </div>
+
+            {/* B-roll Search - Secondary */}
+            <div className="overflow-hidden rounded-[24px] border border-[var(--border)] bg-[var(--background-elevated)]">
+              <div className="flex flex-wrap items-center gap-2 border-b border-[var(--border)] bg-[var(--surface-hover)] px-4 py-3">
+                <span className="rounded-full border border-[var(--border)] px-2 py-1 text-[11px] font-semibold tracking-[0.16em] text-[var(--foreground-secondary)]">
+                  B-ROLL SEARCH
+                </span>
+                <span className="text-xs text-[var(--foreground-secondary)]">Find stock footage and clips</span>
+              </div>
+              <DocsTabs
+                items={[
+                  {
+                    label: "cURL",
+                    value: "curl",
+                    content: (
+                      <CodeBlock
+                        filename="broll-search.sh"
+                        code={`curl "https://api.cerul.ai/v1/search" \\
+  -H "Authorization: Bearer $CERUL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "cinematic drone shot of coastal highway",
+    "search_type": "broll",
+    "max_results": 5
+  }'`}
+                      />
+                    ),
+                  },
+                  {
+                    label: "Python",
+                    value: "python",
+                    content: (
+                      <CodeBlock
+                        filename="search.py"
+                        language="python"
+                        code={`import requests
+
+response = requests.post(
+    "https://api.cerul.ai/v1/search",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    json={
+        "query": "cinematic drone shot of coastal highway",
+        "search_type": "broll",
+        "max_results": 5
+    }
+)
+
+results = response.json()["results"]
+for video in results:
+    print(f"{video['title']}: {video['video_url']}")`}
+                      />
+                    ),
+                  },
+                  {
+                    label: "Response",
+                    value: "response",
+                    content: (
+                      <CodeBlock
+                        filename="broll-response.json"
+                        language="json"
+                        code={`{
+  "results": [
+    {
+      "id": "pexels_28192743",
+      "score": 0.94,
+      "title": "Aerial drone shot of coastal highway",
+      "video_url": "https://videos.pexels.com/video-files/28192743/aerial-coastal-drone.mp4",
+      "thumbnail_url": "https://images.pexels.com/photos/28192743/pexels-photo-28192743.jpeg",
+      "duration": 18,
+      "source": "pexels",
+      "license": "pexels-license"
+    }
+  ],
+  "credits_used": 1,
+  "credits_remaining": 999
+}`}
+                      />
+                    ),
+                  },
+                ]}
+              />
+            </div>
+          </div>
+
+          {/* Documentation sections */}
+          <div className="space-y-12">
             {docsLandingSections.map((section) => (
               <section
                 key={section.id}
                 id={section.id}
-                className="surface scroll-mt-28 px-6 py-6 sm:px-8"
+                className="scroll-mt-24 rounded-[24px] border border-[var(--border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.02))] p-6 sm:p-8"
               >
-                <p className="eyebrow">{section.kicker}</p>
-                <h2 className="display-title mt-3 text-4xl sm:text-5xl">
-                  {section.title}
-                </h2>
-                <p className="mt-4 max-w-3xl text-base leading-7 text-[var(--muted)]">
+                <p className="eyebrow mb-2">{section.kicker}</p>
+                <h2 className="text-2xl font-bold text-white">{section.title}</h2>
+                <p className="mt-3 max-w-3xl text-[var(--foreground-secondary)]">
                   {section.description}
                 </p>
-                {section.list.length > 0 ? (
-                  <ul className="mt-6 grid gap-3 sm:grid-cols-2">
+
+                {section.list.length > 0 && (
+                  <ul className="mt-5 grid gap-3 sm:grid-cols-2">
                     {section.list.map((item) => (
                       <li
                         key={item}
-                        className="rounded-[22px] border border-[var(--line)] bg-white/72 px-4 py-3 text-sm leading-6"
+                        className="flex items-start gap-2 rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground-secondary)]"
                       >
+                        <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[var(--brand)]" />
                         {item}
                       </li>
                     ))}
                   </ul>
-                ) : null}
-                {section.code ? (
-                  <div className="code-window mt-7 px-5 py-5 sm:px-6">
-                    <pre>{section.code}</pre>
+                )}
+
+                {section.code && (
+                  <div className="mt-6">
+                    <CodeBlock
+                      code={section.code}
+                      filename={section.filename || "example.json"}
+                      language={section.language || "json"}
+                    />
                   </div>
-                ) : null}
+                )}
               </section>
             ))}
           </div>
-        </section>
-      </main>
-      <SiteFooter />
+
+          {/* Next steps */}
+          <div className="surface-gradient mt-12 p-6">
+            <h3 className="text-lg font-semibold text-white">Next Steps</h3>
+            <p className="mt-2 text-[var(--foreground-secondary)]">
+              Ready to start building? Check out the guides or open the dashboard.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <Link href="/docs/quickstart" className="button-primary">
+                Read Quickstart
+              </Link>
+              <Link href="/dashboard" className="button-secondary">
+                Open Dashboard
+              </Link>
+            </div>
+          </div>
+        </main>
+
+        {/* Right TOC */}
+        <div className="hidden lg:block">
+          <DocsToc items={tocItems} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,27 +1,62 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f5f0e8;
-  --foreground: #10212d;
-  --muted: #5b6976;
-  --surface: rgba(255, 252, 247, 0.88);
-  --surface-strong: #fffdfa;
-  --surface-dark: #10212d;
-  --line: rgba(16, 33, 45, 0.12);
-  --brand: #0a8ed8;
-  --brand-deep: #0f5d8f;
-  --accent: #ff6b2c;
-  --accent-soft: #ffd3be;
-  --mint: #1ab39a;
-  --sand: #ead4b7;
-  --shadow: 0 22px 60px rgba(17, 29, 39, 0.1);
-  --radius: 28px;
+  /* Core colors - Dark theme */
+  --background: #0a0a0f;
+  --background-elevated: #111118;
+  --background-sunken: #050508;
+
+  --foreground: #fafafa;
+  --foreground-secondary: #a1a1aa;
+  --foreground-tertiary: #71717a;
+
+  /* Brand colors - Electric blue to cyan gradient */
+  --brand: #3b82f6;
+  --brand-bright: #60a5fa;
+  --brand-glow: rgba(59, 130, 246, 0.4);
+  --brand-subtle: rgba(59, 130, 246, 0.1);
+
+  /* Accent - Warm orange for CTAs */
+  --accent: #f97316;
+  --accent-bright: #fb923c;
+  --accent-glow: rgba(249, 115, 22, 0.4);
+  --accent-subtle: rgba(249, 115, 22, 0.1);
+
+  /* Semantic colors */
+  --success: #22c55e;
+  --warning: #eab308;
+  --error: #ef4444;
+
+  /* Surface colors */
+  --surface: rgba(255, 255, 255, 0.03);
+  --surface-hover: rgba(255, 255, 255, 0.06);
+  --surface-active: rgba(255, 255, 255, 0.1);
+  --surface-elevated: rgba(255, 255, 255, 0.05);
+
+  /* Borders */
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.15);
+  --border-brand: rgba(59, 130, 246, 0.3);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 40px rgba(0, 0, 0, 0.5);
+  --shadow-glow: 0 0 40px var(--brand-glow);
+  --shadow-accent-glow: 0 0 40px var(--accent-glow);
+
+  /* Radius */
+  --radius-sm: 6px;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-full: 9999px;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --color-muted: var(--muted);
+  --color-muted: var(--foreground-secondary);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
   --font-display: var(--font-display);
@@ -38,25 +73,38 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at top left, rgba(10, 142, 216, 0.18), transparent 28%),
-    radial-gradient(circle at 85% 12%, rgba(255, 107, 44, 0.15), transparent 20%),
-    linear-gradient(180deg, #fffdfa 0%, #f5f0e8 42%, #f1ebe1 100%);
+  background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-sans), sans-serif;
+  font-family: var(--font-sans), system-ui, -apple-system, sans-serif;
   text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
+/* Ambient background glow */
 body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background:
+    radial-gradient(ellipse 80% 50% at 50% -20%, rgba(59, 130, 246, 0.15), transparent),
+    radial-gradient(ellipse 60% 40% at 80% 50%, rgba(249, 115, 22, 0.08), transparent),
+    radial-gradient(ellipse 50% 30% at 20% 80%, rgba(59, 130, 246, 0.1), transparent);
+  pointer-events: none;
+}
+
+/* Subtle grid pattern */
+body::after {
   content: "";
   position: fixed;
   inset: 0;
   z-index: -1;
   background-image:
-    linear-gradient(rgba(16, 33, 45, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(16, 33, 45, 0.04) 1px, transparent 1px);
-  background-size: 72px 72px;
-  mask-image: radial-gradient(circle at center, black, transparent 78%);
+    linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+  background-size: 60px 60px;
+  mask-image: radial-gradient(circle at center, black 40%, transparent 80%);
   pointer-events: none;
 }
 
@@ -67,7 +115,8 @@ a {
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
 }
 
@@ -75,8 +124,17 @@ button {
   cursor: pointer;
 }
 
+a:focus-visible,
+button:focus-visible,
+[role="tab"]:focus-visible,
+[role="menuitem"]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--brand);
+}
+
 ::selection {
-  background: rgba(10, 142, 216, 0.22);
+  background: rgba(59, 130, 246, 0.3);
+  color: var(--foreground);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -94,124 +152,223 @@ button {
   }
 }
 
+/* ========================================
+   Component Styles
+   ======================================== */
+
+/* Surface cards */
 .surface {
   background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(18px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(16px);
+  transition: all 0.2s ease;
 }
 
-.surface-strong {
-  background: var(--surface-strong);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
+.surface:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-hover);
+}
+
+.surface-elevated {
+  background: var(--surface-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(24px);
   box-shadow: var(--shadow);
 }
 
+.surface-gradient {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(249, 115, 22, 0.05));
+  border: 1px solid var(--border-brand);
+  border-radius: var(--radius-lg);
+}
+
+/* Label/Badge */
 .label {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  border-radius: 999px;
-  border: 1px solid rgba(16, 33, 45, 0.1);
-  background: rgba(255, 255, 255, 0.6);
-  padding: 0.45rem 0.9rem;
-  font-size: 0.72rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 0.4rem 0.9rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+  color: var(--foreground-secondary);
+}
+
+.label-brand {
+  border-color: var(--border-brand);
+  background: var(--brand-subtle);
+  color: var(--brand-bright);
+}
+
+.label-accent {
+  border-color: rgba(249, 115, 22, 0.3);
+  background: var(--accent-subtle);
+  color: var(--accent-bright);
 }
 
 .label::before {
   content: "";
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--brand), var(--accent));
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
 }
 
+/* Typography */
 .display-title {
-  font-family: var(--font-display), sans-serif;
+  font-family: var(--font-display), system-ui, sans-serif;
   font-weight: 700;
-  line-height: 0.95;
-  letter-spacing: -0.05em;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, var(--foreground) 0%, var(--foreground-secondary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
-.copy-muted {
-  color: var(--muted);
+.display-title-gradient {
+  font-family: var(--font-display), system-ui, sans-serif;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, var(--foreground) 0%, var(--brand-bright) 50%, var(--accent-bright) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .eyebrow {
   font-family: var(--font-mono), monospace;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   font-weight: 500;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: var(--brand-deep);
+  color: var(--brand-bright);
 }
 
+.text-muted {
+  color: var(--foreground-secondary);
+}
+
+.text-tertiary {
+  color: var(--foreground-tertiary);
+}
+
+/* Buttons */
 .button-primary {
   display: inline-flex;
-  min-height: 3rem;
+  min-height: 2.75rem;
   align-items: center;
   justify-content: center;
-  gap: 0.65rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 107, 44, 0.2);
-  background: linear-gradient(135deg, var(--accent), #ff8551);
-  padding: 0.85rem 1.35rem;
+  gap: 0.5rem;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, var(--brand), #2563eb);
+  padding: 0.6rem 1.25rem;
   color: white;
   font-weight: 600;
-  transition:
-    transform 180ms ease,
-    box-shadow 180ms ease,
-    background 180ms ease;
-  box-shadow: 0 14px 30px rgba(255, 107, 44, 0.22);
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 20px rgba(59, 130, 246, 0.3);
 }
 
-.button-primary:hover,
-.button-primary:focus-visible {
+.button-primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 36px rgba(255, 107, 44, 0.28);
+  box-shadow: 0 6px 30px rgba(59, 130, 246, 0.4);
+  background: linear-gradient(135deg, var(--brand-bright), var(--brand));
+}
+
+.button-primary:active {
+  transform: translateY(0);
 }
 
 .button-secondary {
   display: inline-flex;
-  min-height: 3rem;
+  min-height: 2.75rem;
   align-items: center;
   justify-content: center;
-  gap: 0.65rem;
-  border-radius: 999px;
-  border: 1px solid rgba(16, 33, 45, 0.12);
-  background: rgba(255, 255, 255, 0.7);
-  padding: 0.85rem 1.35rem;
+  gap: 0.5rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 0.6rem 1.25rem;
+  color: var(--foreground);
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.button-secondary:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.button-ghost {
+  display: inline-flex;
+  min-height: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 0.5rem 1rem;
+  color: var(--foreground-secondary);
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.button-ghost:hover {
+  color: var(--foreground);
+  background: var(--surface);
+}
+
+.button-accent {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, var(--accent), #ea580c);
+  padding: 0.6rem 1.25rem;
+  color: white;
   font-weight: 600;
-  transition:
-    transform 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 20px rgba(249, 115, 22, 0.3);
 }
 
-.button-secondary:hover,
-.button-secondary:focus-visible {
+.button-accent:hover {
   transform: translateY(-1px);
-  border-color: rgba(10, 142, 216, 0.26);
-  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 6px 30px rgba(249, 115, 22, 0.4);
 }
 
+/* Navigation */
 .nav-link {
   position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  color: var(--muted);
-  font-size: 0.96rem;
-  transition: color 160ms ease;
+  color: var(--foreground-secondary);
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.5rem 0;
+  transition: color 0.2s ease;
 }
 
 .nav-link:hover,
-.nav-link:focus-visible,
+.nav-link:focus-visible {
+  color: var(--foreground);
+}
+
 .nav-link-active {
   color: var(--foreground);
 }
@@ -221,30 +378,19 @@ button {
   position: absolute;
   left: 0;
   right: 0;
-  bottom: -0.55rem;
+  bottom: -2px;
   height: 2px;
-  border-radius: 999px;
+  border-radius: 2px;
   background: linear-gradient(90deg, var(--brand), var(--accent));
 }
 
-.grid-lines {
-  position: relative;
-}
-
-.grid-lines::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid rgba(10, 142, 216, 0.08);
-  pointer-events: none;
-}
-
+/* Chart bars */
 .chart-bar {
   position: relative;
   overflow: hidden;
-  border-radius: 999px;
-  background: rgba(16, 33, 45, 0.08);
+  border-radius: var(--radius-full);
+  background: var(--surface);
+  height: 8px;
 }
 
 .chart-bar > span {
@@ -252,42 +398,154 @@ button {
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, var(--brand), var(--accent));
+  box-shadow: 0 0 10px var(--brand-glow);
+  transition: width 0.5s ease;
 }
 
+/* Code window */
 .code-window {
-  border-radius: 24px;
-  border: 1px solid rgba(16, 33, 45, 0.1);
-  background: linear-gradient(180deg, rgba(18, 31, 43, 0.97), rgba(9, 18, 27, 0.96));
-  color: #f7fafc;
-  box-shadow: 0 26px 60px rgba(8, 18, 29, 0.18);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--background-elevated);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
 }
+
+.code-window-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.code-window-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.code-window-dot-red { background: #ff5f56; }
+.code-window-dot-yellow { background: #ffbd2e; }
+.code-window-dot-green { background: #27ca40; }
 
 .code-window pre {
   margin: 0;
+  padding: 1.25rem;
   overflow-x: auto;
   font-family: var(--font-mono), monospace;
-  font-size: 0.88rem;
+  font-size: 0.875rem;
   line-height: 1.7;
+  color: #e4e4e7;
 }
 
+/* Dashboard sidebar */
 .dashboard-sidebar-link {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  border-radius: 18px;
-  padding: 0.8rem 0.95rem;
-  color: var(--muted);
-  transition:
-    transform 180ms ease,
-    background 180ms ease,
-    color 180ms ease;
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  color: var(--foreground-secondary);
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
 }
 
 .dashboard-sidebar-link:hover,
-.dashboard-sidebar-link:focus-visible,
-.dashboard-sidebar-link-active {
-  transform: translateX(2px);
-  background: rgba(10, 142, 216, 0.08);
+.dashboard-sidebar-link:focus-visible {
+  background: var(--surface);
   color: var(--foreground);
+}
+
+.dashboard-sidebar-link-active {
+  background: var(--brand-subtle);
+  color: var(--brand-bright);
+  border: 1px solid var(--border-brand);
+}
+
+/* Status badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-full);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.badge-success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.badge-warning {
+  background: rgba(234, 179, 8, 0.15);
+  color: #facc15;
+  border: 1px solid rgba(234, 179, 8, 0.3);
+}
+
+.badge-error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #f87171;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+/* Glow effects */
+.glow-brand {
+  box-shadow: 0 0 30px var(--brand-glow);
+}
+
+.glow-accent {
+  box-shadow: 0 0 30px var(--accent-glow);
+}
+
+/* Gradient borders */
+.gradient-border {
+  position: relative;
+  background: var(--background);
+  border-radius: var(--radius-lg);
+}
+
+.gradient-border::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 1px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--brand), var(--accent));
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+/* Focus styles */
+.focus-ring:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--brand);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--surface);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--foreground-tertiary);
 }

--- a/frontend/app/icon.svg
+++ b/frontend/app/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="cerul-icon-gradient" x1="8" x2="56" y1="8" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#60A5FA" />
+      <stop offset="1" stop-color="#F97316" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="18" fill="#0A0A0F" />
+  <path
+    d="M44 16h-9.5c-10.2 0-18.5 7.6-18.5 16.9S24.3 49.7 34.5 49.7H44v-8.1h-9.2c-5.5 0-9.8-3.8-9.8-8.7s4.3-8.7 9.8-8.7H44V16Z"
+    fill="url(#cerul-icon-gradient)"
+  />
+</svg>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -16,22 +16,22 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col px-5 pb-8 pt-5 sm:px-8 lg:px-10">
+    <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
       <SiteHeader currentPath="/login" />
-      <main className="grid flex-1 gap-6 pb-8 pt-10 lg:grid-cols-[0.9fr_1.1fr]">
-        <section className="surface px-6 py-6 sm:px-8">
+      <main className="grid flex-1 gap-6 pb-8 pt-10 lg:grid-cols-2">
+        <section className="surface-elevated px-6 py-6 lg:px-8">
           <p className="eyebrow">Operator access</p>
-          <h1 className="display-title mt-3 text-5xl sm:text-6xl">
+          <h1 className="mt-3 text-3xl font-bold text-white sm:text-4xl">
             Sign in to manage keys and usage.
           </h1>
-          <div className="mt-6 space-y-4">
+          <div className="mt-6 space-y-3">
             {authValueProps.map((item) => (
               <div
                 key={item.title}
-                className="rounded-[22px] border border-[var(--line)] bg-white/76 px-4 py-4"
+                className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-4"
               >
-                <h2 className="text-lg font-semibold tracking-tight">{item.title}</h2>
-                <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
+                <h2 className="font-semibold text-white">{item.title}</h2>
+                <p className="mt-2 text-sm text-[var(--foreground-tertiary)]">
                   {item.description}
                 </p>
               </div>
@@ -39,25 +39,25 @@ export default function LoginPage() {
           </div>
         </section>
 
-        <section className="surface px-6 py-6 sm:px-8">
-          <form className="rounded-[24px] border border-[var(--line)] bg-white/82 p-5">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-              Mock sign-in
+        <section className="surface-elevated px-6 py-6 lg:px-8">
+          <form className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5">
+            <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+              Sign in
             </p>
             <div className="mt-5 space-y-4">
               <label className="block">
-                <span className="mb-2 block text-sm font-medium">Work email</span>
+                <span className="mb-2 block text-sm font-medium text-[var(--foreground-secondary)]">Work email</span>
                 <input
-                  className="h-12 w-full rounded-[18px] border border-[var(--line)] bg-transparent px-4 outline-none focus:border-[rgba(10,142,216,0.24)]"
+                  className="h-11 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 text-white outline-none transition-all placeholder:text-[var(--foreground-tertiary)] focus:border-[var(--brand)] focus:ring-1 focus:ring-[var(--brand)]"
                   type="email"
                   placeholder="you@company.com"
                   autoComplete="email"
                 />
               </label>
               <label className="block">
-                <span className="mb-2 block text-sm font-medium">Password</span>
+                <span className="mb-2 block text-sm font-medium text-[var(--foreground-secondary)]">Password</span>
                 <input
-                  className="h-12 w-full rounded-[18px] border border-[var(--line)] bg-transparent px-4 outline-none focus:border-[rgba(10,142,216,0.24)]"
+                  className="h-11 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 text-white outline-none transition-all placeholder:text-[var(--foreground-tertiary)] focus:border-[var(--brand)] focus:ring-1 focus:ring-[var(--brand)]"
                   type="password"
                   placeholder="••••••••"
                   autoComplete="current-password"
@@ -67,9 +67,9 @@ export default function LoginPage() {
             <button type="submit" className="button-primary mt-6 w-full">
               Continue to console
             </button>
-            <p className="mt-4 text-sm text-[var(--muted)]">
+            <p className="mt-4 text-sm text-[var(--foreground-tertiary)]">
               Need an account?{" "}
-              <Link href="/signup" className="font-semibold text-[var(--brand-deep)]">
+              <Link href="/signup" className="font-medium text-[var(--brand-bright)] hover:underline">
                 Create one
               </Link>
             </p>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -39,116 +39,283 @@ export default function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col px-5 pb-8 pt-5 sm:px-8 lg:px-10">
+      <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
         <SiteHeader currentPath="/" />
         <main className="flex-1">
-          <section className="grid gap-8 pb-14 pt-10 lg:grid-cols-[1.15fr_0.85fr] lg:items-center lg:gap-14 lg:pt-16">
-            <div className="space-y-8">
-              <div className="space-y-5">
-                <span className="label">Video understanding for AI agents</span>
-                <div className="space-y-4">
-                  <p className="eyebrow">The video access layer for reasoning systems</p>
-                  <h1 className="display-title max-w-[12ch] text-5xl sm:text-6xl lg:text-8xl">
+          {/* Hero Section */}
+          <section className="relative py-16 lg:py-24">
+            <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center lg:gap-16">
+              <div className="space-y-8">
+                <div className="space-y-6">
+                  <span className="label label-brand">Video understanding for AI agents</span>
+                  <h1 className="display-title-gradient text-4xl sm:text-5xl lg:text-6xl xl:text-7xl">
                     Search what is shown in videos.
                   </h1>
+                  <p className="max-w-xl text-lg leading-relaxed text-[var(--foreground-secondary)]">
+                    Cerul turns slides, charts, demos, code screens, and whiteboards
+                    into queryable evidence for agents. One platform backbone, two
+                    tracks: lightweight b-roll discovery and knowledge-dense retrieval.
+                  </p>
                 </div>
-                <p className="max-w-2xl text-lg leading-8 text-[var(--muted)] sm:text-xl">
-                  Cerul turns slides, charts, demos, code screens, and whiteboards
-                  into queryable evidence for agents. One platform backbone, two
-                  tracks: lightweight b-roll discovery and knowledge-dense retrieval.
-                </p>
+                <div className="flex flex-wrap gap-3">
+                  <Link href="/docs" className="button-primary">
+                    Explore docs
+                  </Link>
+                  <Link href="/dashboard" className="button-secondary">
+                    Open console
+                  </Link>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-3">
+                  {marketingMetrics.map((metric) => (
+                    <div key={metric.label} className="surface px-5 py-4">
+                      <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--brand-bright)]">
+                        {metric.label}
+                      </p>
+                      <p className="mt-3 text-2xl font-bold text-white">
+                        {metric.value}
+                      </p>
+                      <p className="mt-1 text-sm text-[var(--foreground-tertiary)]">
+                        {metric.caption}
+                      </p>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Link href="/docs" className="button-primary">
-                  Explore docs
-                </Link>
-                <Link href="/dashboard" className="button-secondary">
-                  Open console
-                </Link>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-3">
-                {marketingMetrics.map((metric) => (
-                  <div key={metric.label} className="surface px-5 py-5">
-                    <p className="font-mono text-sm text-[var(--brand-deep)]">{metric.label}</p>
-                    <p className="mt-4 text-3xl font-semibold tracking-tight">
-                      {metric.value}
-                    </p>
-                    <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
-                      {metric.caption}
-                    </p>
+              <AgentDemoConsole />
+            </div>
+          </section>
+
+          {/* API Example Section - RIGHT AFTER HERO */}
+          <section className="py-8">
+            <div className="surface-elevated overflow-hidden">
+              <div className="border-b border-[var(--border)] bg-[var(--surface)] px-6 py-4">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="eyebrow">Try it now</p>
+                    <h2 className="mt-1 text-xl font-bold text-white">
+                      Copy, paste, run. Get video results in seconds.
+                    </h2>
                   </div>
-                ))}
+                  <Link href="/docs" className="button-secondary text-sm">
+                    Full API reference →
+                  </Link>
+                </div>
+              </div>
+
+              {/* Knowledge Search - Primary */}
+              <div className="border-b border-[var(--border)]">
+                <div className="bg-[var(--brand-subtle)] px-6 py-2">
+                  <span className="text-xs font-medium text-[var(--brand-bright)]">KNOWLEDGE SEARCH</span>
+                  <span className="ml-2 text-xs text-[var(--foreground-tertiary)]">Find insights from interviews and talks</span>
+                </div>
+                <div className="grid gap-0 lg:grid-cols-2">
+                  {/* Request */}
+                  <div className="border-b border-[var(--border)] lg:border-b-0 lg:border-r">
+                    <div className="code-window-header">
+                      <div className="flex items-center gap-2">
+                        <span className="code-window-dot code-window-dot-red" />
+                        <span className="code-window-dot code-window-dot-yellow" />
+                        <span className="code-window-dot code-window-dot-green" />
+                        <span className="ml-2 font-mono text-xs text-[var(--foreground-tertiary)]">knowledge-search.sh</span>
+                      </div>
+                      <span className="rounded bg-[var(--brand-subtle)] px-2 py-0.5 text-xs font-medium text-[var(--brand-bright)]">POST</span>
+                    </div>
+                    <pre className="p-4 text-sm">{`curl "https://api.cerul.ai/v1/search" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "Sam Altman views on AI video generation tools",
+    "search_type": "knowledge",
+    "max_results": 3,
+    "include_answer": true
+  }'`}</pre>
+                  </div>
+                  {/* Response */}
+                  <div>
+                    <div className="code-window-header">
+                      <div className="flex items-center gap-2">
+                        <span className="code-window-dot code-window-dot-red" />
+                        <span className="code-window-dot code-window-dot-yellow" />
+                        <span className="code-window-dot code-window-dot-green" />
+                        <span className="ml-2 font-mono text-xs text-[var(--foreground-tertiary)]">knowledge-response.json</span>
+                      </div>
+                      <span className="rounded bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-400">200 OK</span>
+                    </div>
+                    <pre className="p-4 text-sm">{`{
+  "results": [
+    {
+      "id": "yt_hmtuvNfytjM_1223",
+      "score": 0.96,
+      "title": "Sam Altman on the Future of AI Creative Tools",
+      "description": "OpenAI CEO discusses the implications of AI video generation for creative industries",
+      "video_url": "https://www.youtube.com/watch?v=hmtuvNfytjM&t=1223s",
+      "thumbnail_url": "https://i.ytimg.com/vi/hmtuvNfytjM/hqdefault.jpg",
+      "source": "youtube",
+      "speaker": "Sam Altman",
+      "timestamp_start": 1223,
+      "timestamp_end": 1345,
+      "duration": 122,
+      "answer": "Altman believes AI video generation will democratize filmmaking, allowing anyone to create professional content. He emphasizes the importance of human creativity in prompting and curation."
+    },
+    {
+      "id": "yt_8XJ6z1K3n9P_445",
+      "score": 0.91,
+      "title": "Fireside Chat: AI and the Future of Media",
+      "description": "Discussion on how AI tools are reshaping video production and storytelling",
+      "video_url": "https://www.youtube.com/watch?v=8XJ6z1K3n9P&t=445s",
+      "thumbnail_url": "https://i.ytimg.com/vi/8XJ6z1K3n9P/hqdefault.jpg",
+      "source": "youtube",
+      "speaker": "Sam Altman",
+      "timestamp_start": 445,
+      "timestamp_end": 582,
+      "duration": 137
+    }
+  ],
+  "credits_used": 2,
+  "credits_remaining": 998,
+  "request_id": "req_know_20240310_xyz"
+}`}</pre>
+                  </div>
+                </div>
+              </div>
+
+              {/* B-roll Search - Secondary */}
+              <div>
+                <div className="bg-[var(--surface-hover)] px-6 py-2">
+                  <span className="text-xs font-medium text-[var(--foreground-secondary)]">B-ROLL SEARCH</span>
+                  <span className="ml-2 text-xs text-[var(--foreground-tertiary)]">Find stock footage and clips</span>
+                </div>
+                <div className="grid gap-0 lg:grid-cols-2">
+                  {/* Request */}
+                  <div className="border-b border-[var(--border)] lg:border-b-0 lg:border-r">
+                    <div className="code-window-header">
+                      <div className="flex items-center gap-2">
+                        <span className="code-window-dot code-window-dot-red" />
+                        <span className="code-window-dot code-window-dot-yellow" />
+                        <span className="code-window-dot code-window-dot-green" />
+                        <span className="ml-2 font-mono text-xs text-[var(--foreground-tertiary)]">broll-search.sh</span>
+                      </div>
+                      <span className="rounded bg-[var(--accent-subtle)] px-2 py-0.5 text-xs font-medium text-[var(--accent-bright)]">POST</span>
+                    </div>
+                    <pre className="p-4 text-sm">{`curl "https://api.cerul.ai/v1/search" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "cinematic drone shot of coastal highway",
+    "search_type": "broll",
+    "max_results": 3
+  }'`}</pre>
+                  </div>
+                  {/* Response */}
+                  <div>
+                    <div className="code-window-header">
+                      <div className="flex items-center gap-2">
+                        <span className="code-window-dot code-window-dot-red" />
+                        <span className="code-window-dot code-window-dot-yellow" />
+                        <span className="code-window-dot code-window-dot-green" />
+                        <span className="ml-2 font-mono text-xs text-[var(--foreground-tertiary)]">broll-response.json</span>
+                      </div>
+                      <span className="rounded bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-400">200 OK</span>
+                    </div>
+                    <pre className="p-4 text-sm">{`{
+  "results": [
+    {
+      "id": "pexels_28192743",
+      "score": 0.94,
+      "title": "Aerial drone shot of coastal highway",
+      "description": "Cinematic 4K drone footage of winding coastal road",
+      "video_url": "https://videos.pexels.com/video-files/28192743/aerial-coastal-drone.mp4",
+      "thumbnail_url": "https://images.pexels.com/photos/28192743/pexels-photo-28192743.jpeg",
+      "duration": 18,
+      "source": "pexels",
+      "license": "pexels-license"
+    }
+  ],
+  "credits_used": 1,
+  "credits_remaining": 999
+}`}</pre>
+                  </div>
+                </div>
               </div>
             </div>
-            <AgentDemoConsole />
           </section>
 
-          <section className="py-12">
-            <div className="surface grid gap-8 px-6 py-8 sm:px-8 lg:grid-cols-[0.9fr_1.1fr] lg:px-10">
-              <div className="space-y-4">
-                <p className="eyebrow">Why this exists</p>
-                <h2 className="display-title text-4xl sm:text-5xl">
-                  Transcripts are not enough.
-                </h2>
-                <p className="max-w-xl text-base leading-7 text-[var(--muted)] sm:text-lg">
-                  Agents can already search web pages. The missing layer is visual
-                  evidence inside videos. Cerul indexes what was actually on screen,
-                  not only what happened to be spoken.
-                </p>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-3">
-                {capabilityHighlights.map((item) => (
-                  <article key={item.title} className="surface-strong grid-lines px-5 py-5">
-                    <p className="font-mono text-sm text-[var(--brand-deep)]">{item.kicker}</p>
-                    <h3 className="mt-4 text-xl font-semibold tracking-tight">
-                      {item.title}
-                    </h3>
-                    <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-                      {item.description}
-                    </p>
-                  </article>
-                ))}
+          {/* Why Section */}
+          <section className="py-16">
+            <div className="surface-elevated px-6 py-8 lg:px-10 lg:py-12">
+              <div className="grid gap-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+                <div className="space-y-4">
+                  <p className="eyebrow">Why Cerul</p>
+                  <h2 className="text-3xl font-bold text-white sm:text-4xl">
+                    Transcripts are not enough.
+                  </h2>
+                  <p className="text-[var(--foreground-secondary)]">
+                    Agents can already search web pages. The missing layer is visual
+                    evidence inside videos. Cerul indexes what was actually on screen,
+                    not only what happened to be spoken.
+                  </p>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-3">
+                  {capabilityHighlights.map((item) => (
+                    <article key={item.title} className="surface px-4 py-4">
+                      <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--brand-bright)]">
+                        {item.kicker}
+                      </p>
+                      <h3 className="mt-3 text-lg font-semibold text-white">
+                        {item.title}
+                      </h3>
+                      <p className="mt-2 text-sm leading-relaxed text-[var(--foreground-tertiary)]">
+                        {item.description}
+                      </p>
+                    </article>
+                  ))}
+                </div>
               </div>
             </div>
           </section>
 
-          <section className="py-12">
-            <div className="mb-7 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          {/* Two Tracks Section */}
+          <section className="py-16">
+            <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <p className="eyebrow">Two tracks, one platform</p>
-                <h2 className="display-title text-4xl sm:text-5xl">
-                  Ship the showcase first. Keep the deeper moat.
+                <h2 className="mt-3 text-3xl font-bold text-white sm:text-4xl">
+                  Ship the showcase first.
+                  <br />
+                  <span className="text-[var(--foreground-secondary)]">Keep the deeper moat.</span>
                 </h2>
               </div>
-              <p className="max-w-xl text-base leading-7 text-[var(--muted)]">
+              <p className="max-w-md text-[var(--foreground-secondary)]">
                 The front end borrows Tavily&apos;s unified product rhythm: one brand,
-                one stack, distinct product surfaces. Cerul does the same for b-roll
-                search and knowledge retrieval.
+                one stack, distinct product surfaces.
               </p>
             </div>
             <div className="grid gap-5 lg:grid-cols-2">
               {searchTracks.map((track) => (
-                <article key={track.name} className="surface grid-lines px-6 py-6 sm:px-7">
-                  <div className="flex items-center justify-between gap-4">
+                <article key={track.name} className="surface-elevated px-6 py-6">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
                     <div>
-                      <p className="font-mono text-sm text-[var(--brand-deep)]">{track.badge}</p>
-                      <h3 className="mt-2 text-3xl font-semibold tracking-tight">
+                      <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--brand-bright)]">
+                        {track.badge}
+                      </p>
+                      <h3 className="mt-2 text-2xl font-bold text-white">
                         {track.name}
                       </h3>
                     </div>
-                    <span className="rounded-full border border-[var(--line)] bg-white/70 px-3 py-1 font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
+                    <span className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-3 py-1 font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
                       {track.grain}
                     </span>
                   </div>
-                  <p className="mt-4 max-w-xl text-base leading-7 text-[var(--muted)]">
+                  <p className="mt-4 text-[var(--foreground-secondary)]">
                     {track.description}
                   </p>
-                  <ul className="mt-6 grid gap-3 sm:grid-cols-2">
+                  <ul className="mt-6 grid gap-2 sm:grid-cols-2">
                     {track.points.map((point) => (
                       <li
                         key={point}
-                        className="rounded-2xl border border-[var(--line)] bg-white/68 px-4 py-3 text-sm leading-6 text-[var(--foreground)]"
+                        className="flex items-start gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2.5 text-sm text-[var(--foreground-secondary)]"
                       >
+                        <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[var(--brand)]" />
                         {point}
                       </li>
                     ))}
@@ -158,61 +325,62 @@ export default function HomePage() {
             </div>
           </section>
 
-          <section className="py-12">
-            <div className="grid gap-5 lg:grid-cols-[1.1fr_0.9fr]">
-              <article className="surface px-6 py-6 sm:px-8">
+          {/* Benchmark & Dashboard Section */}
+          <section className="py-16">
+            <div className="grid gap-5 lg:grid-cols-2">
+              <article className="surface-elevated px-6 py-6 lg:px-8">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                   <div>
-                    <p className="eyebrow">Benchmark posture</p>
-                    <h2 className="display-title text-4xl sm:text-5xl">
+                    <p className="eyebrow">Benchmarks</p>
+                    <h2 className="mt-3 text-2xl font-bold text-white">
                       Make evaluation visible.
                     </h2>
                   </div>
-                  <p className="max-w-md text-sm leading-6 text-[var(--muted)]">
-                    Tavily leans on benchmarks to establish trust. Cerul should do the
-                    same, especially where transcript-only systems lose visual recall.
+                  <p className="max-w-xs text-sm text-[var(--foreground-tertiary)]">
+                    Cerul leans on benchmarks to establish trust, especially where transcript-only systems lose visual recall.
                   </p>
                 </div>
-                <div className="mt-8 space-y-4">
+                <div className="mt-8 space-y-5">
                   {benchmarkRows.map((row) => (
                     <div key={row.label} className="grid gap-3 sm:grid-cols-[1fr_2fr_auto] sm:items-center">
                       <div>
-                        <p className="font-medium">{row.label}</p>
-                        <p className="text-sm text-[var(--muted)]">{row.description}</p>
+                        <p className="font-medium text-white">{row.label}</p>
+                        <p className="text-sm text-[var(--foreground-tertiary)]">{row.description}</p>
                       </div>
-                      <div className="chart-bar h-3">
+                      <div className="chart-bar">
                         <span style={{ width: `${row.score}%` }} />
                       </div>
-                      <p className="font-mono text-sm text-[var(--brand-deep)]">{row.score}%</p>
+                      <p className="font-mono text-sm text-[var(--brand-bright)]">{row.score}%</p>
                     </div>
                   ))}
                 </div>
               </article>
-              <article className="surface px-6 py-6 sm:px-8">
-                <p className="eyebrow">Operator cockpit</p>
-                <h2 className="display-title text-4xl sm:text-5xl">
-                  One console for usage, keys, and pipelines.
+
+              <article className="surface-gradient px-6 py-6 lg:px-8">
+                <p className="eyebrow">Operator console</p>
+                <h2 className="mt-3 text-2xl font-bold text-white">
+                  One dashboard for usage, keys, and pipelines.
                 </h2>
-                <div className="mt-7 grid gap-4">
+                <div className="mt-6 grid gap-3">
                   {dashboardSignals.map((signal) => (
                     <div
                       key={signal.label}
-                      className="rounded-[24px] border border-[var(--line)] bg-white/72 px-5 py-4"
+                      className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-4"
                     >
                       <div className="flex items-start justify-between gap-4">
                         <div>
-                          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
+                          <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
                             {signal.label}
                           </p>
-                          <p className="mt-3 text-3xl font-semibold tracking-tight">
+                          <p className="mt-2 text-2xl font-bold text-white">
                             {signal.value}
                           </p>
                         </div>
-                        <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--accent)]">
+                        <span className="rounded-full bg-[var(--accent-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--accent-bright)]">
                           {signal.change}
                         </span>
                       </div>
-                      <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+                      <p className="mt-2 text-sm text-[var(--foreground-tertiary)]">
                         {signal.caption}
                       </p>
                     </div>
@@ -222,98 +390,41 @@ export default function HomePage() {
             </div>
           </section>
 
-          <section className="py-12">
-            <div className="grid gap-5 lg:grid-cols-[0.92fr_1.08fr]">
-              <article className="surface-strong px-6 py-6 sm:px-8">
-                <p className="eyebrow">Docs preview</p>
-                <h2 className="display-title mt-3 text-4xl sm:text-5xl">
-                  Clear API shape. Thin product surface.
-                </h2>
-                <p className="mt-4 max-w-xl text-base leading-7 text-[var(--muted)]">
-                  Docs should immediately tell developers what the two public endpoints
-                  are, what payload shape to send, and how the b-roll and knowledge
-                  tracks diverge.
-                </p>
-                <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-                  <Link href="/docs" className="button-primary">
-                    Read the docs
-                  </Link>
-                  <a
-                    className="button-secondary"
-                    href="https://github.com/JessyTsui/cerul"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    View repository
-                  </a>
-                </div>
-              </article>
-              <article className="code-window px-5 py-5 sm:px-7 sm:py-7">
-                <div className="mb-5 flex items-center gap-2">
-                  <span className="h-3 w-3 rounded-full bg-[#ff6b6b]" />
-                  <span className="h-3 w-3 rounded-full bg-[#ffbf69]" />
-                  <span className="h-3 w-3 rounded-full bg-[#57cc99]" />
-                </div>
-                <pre>
-{`POST /v1/search
-
-{
-  "query": "cinematic drone shot of coastal highway at sunset",
-  "search_type": "broll",
-  "max_results": 10,
-  "filters": {
-    "source": "pexels",
-    "min_duration": 5,
-    "max_duration": 30
-  }
-}
-
-{
-  "results": [
-    {
-      "id": "pexels_28192743",
-      "score": 0.89,
-      "duration": 18,
-      "description": "Aerial drone shot of a winding coastal road at sunset."
-    }
-  ]
-}`}
-                </pre>
-              </article>
-            </div>
-          </section>
-
-          <section className="py-12">
-            <div className="mb-7 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          {/* Pricing Preview Section */}
+          <section className="py-16">
+            <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <p className="eyebrow">Pricing preview</p>
-                <h2 className="display-title text-4xl sm:text-5xl">
+                <p className="eyebrow">Pricing</p>
+                <h2 className="mt-3 text-3xl font-bold text-white">
                   Keep pricing operator-readable.
                 </h2>
               </div>
               <Link href="/pricing" className="button-secondary">
-                Open pricing
+                View all plans
               </Link>
             </div>
-            <div className="grid gap-5 lg:grid-cols-3">
+            <div className="grid gap-4 lg:grid-cols-3">
               {pricingTiers.map((tier) => (
-                <article key={tier.name} className="surface grid-lines px-6 py-6">
-                  <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--brand-deep)]">
+                <article key={tier.name} className={`surface px-5 py-5 ${tier.accent === "orange" ? "border-[var(--accent)]/30" : ""}`}>
+                  <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--brand-bright)]">
                     {tier.name}
                   </p>
-                  <div className="mt-4 flex items-end gap-3">
-                    <p className="text-4xl font-semibold tracking-tight">{tier.price}</p>
-                    <p className="pb-1 text-sm text-[var(--muted)]">{tier.cadence}</p>
+                  <div className="mt-4 flex items-end gap-2">
+                    <p className="text-4xl font-bold text-white">{tier.price}</p>
+                    <p className="mb-1 text-sm text-[var(--foreground-tertiary)]">{tier.cadence}</p>
                   </div>
-                  <p className="mt-4 text-sm leading-6 text-[var(--muted)]">
+                  <p className="mt-4 text-sm text-[var(--foreground-tertiary)]">
                     {tier.description}
                   </p>
-                  <ul className="mt-5 space-y-3">
+                  <ul className="mt-5 space-y-2">
                     {tier.features.slice(0, 3).map((feature) => (
                       <li
                         key={feature}
-                        className="rounded-[18px] border border-[var(--line)] bg-white/72 px-4 py-3 text-sm leading-6"
+                        className="flex items-center gap-2 text-sm text-[var(--foreground-secondary)]"
                       >
+                        <svg className="h-4 w-4 text-[var(--success)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
                         {feature}
                       </li>
                     ))}

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -14,18 +14,19 @@ export const metadata: Metadata = {
 
 export default function PricingPage() {
   return (
-    <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col px-5 pb-8 pt-5 sm:px-8 lg:px-10">
+    <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
       <SiteHeader currentPath="/pricing" />
-      <main className="flex-1 pb-12 pt-10">
-        <section className="surface px-6 py-7 sm:px-8">
-          <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-end">
-            <div>
-              <span className="label">Pricing</span>
-              <h1 className="display-title mt-5 text-5xl sm:text-6xl">
+      <main className="flex-1">
+        {/* Hero */}
+        <section className="surface-elevated mt-8 px-6 py-10 lg:px-10">
+          <div className="grid gap-8 lg:grid-cols-2 lg:items-end">
+            <div className="space-y-4">
+              <span className="label label-brand">Pricing</span>
+              <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
                 Credits that map cleanly to product value.
               </h1>
             </div>
-            <p className="text-lg leading-8 text-[var(--muted)]">
+            <p className="max-w-lg text-lg text-[var(--foreground-secondary)]">
               Cerul prices the same public API surface used by direct clients, docs,
               and installable skills. Start with evaluation credits, then scale into
               predictable operator workflows.
@@ -33,43 +34,74 @@ export default function PricingPage() {
           </div>
         </section>
 
-        <section className="grid gap-5 pt-8 lg:grid-cols-3">
-          {pricingTiers.map((tier) => (
+        {/* Pricing tiers */}
+        <section className="mt-8 grid gap-4 lg:grid-cols-3">
+          {pricingTiers.map((tier, index) => (
             <article
               key={tier.name}
               className={`surface px-6 py-6 ${
-                tier.accent === "orange"
-                  ? "bg-[linear-gradient(180deg,rgba(255,240,230,0.92),rgba(255,252,247,0.88))]"
+                index === 1
+                  ? "relative border-[var(--accent)]/40 lg:scale-105"
                   : ""
               }`}
             >
-              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--brand-deep)]">
+              {index === 1 && (
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-[var(--accent)] px-3 py-1 text-xs font-semibold text-white">
+                  Most Popular
+                </div>
+              )}
+              <p className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--brand-bright)]">
                 {tier.name}
               </p>
-              <div className="mt-4 flex items-end gap-3">
-                <p className="text-5xl font-semibold tracking-tight">{tier.price}</p>
-                <p className="pb-2 text-sm text-[var(--muted)]">{tier.cadence}</p>
+              <div className="mt-4 flex items-end gap-2">
+                <p className="text-5xl font-bold text-white">{tier.price}</p>
+                <p className="mb-2 text-sm text-[var(--foreground-tertiary)]">
+                  {tier.cadence}
+                </p>
               </div>
-              <p className="mt-4 text-sm leading-7 text-[var(--muted)]">
+              <p className="mt-4 text-[var(--foreground-secondary)]">
                 {tier.description}
               </p>
               <ul className="mt-6 space-y-3">
                 {tier.features.map((feature) => (
                   <li
                     key={feature}
-                    className="rounded-[18px] border border-[var(--line)] bg-white/74 px-4 py-3 text-sm leading-6"
+                    className="flex items-start gap-3 text-sm text-[var(--foreground-secondary)]"
                   >
+                    <svg
+                      className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--success)]"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
                     {feature}
                   </li>
                 ))}
               </ul>
               <div className="mt-6">
                 {tier.ctaHref.startsWith("mailto:") ? (
-                  <a href={tier.ctaHref} className="button-primary">
+                  <a
+                    href={tier.ctaHref}
+                    className={`w-full ${
+                      index === 1 ? "button-accent" : "button-secondary"
+                    }`}
+                  >
                     {tier.ctaLabel}
                   </a>
                 ) : (
-                  <Link href={tier.ctaHref} className="button-primary">
+                  <Link
+                    href={tier.ctaHref}
+                    className={`w-full ${
+                      index === 1 ? "button-accent" : "button-secondary"
+                    }`}
+                  >
                     {tier.ctaLabel}
                   </Link>
                 )}
@@ -78,28 +110,30 @@ export default function PricingPage() {
           ))}
         </section>
 
-        <section className="grid gap-5 pt-10 lg:grid-cols-[0.9fr_1.1fr]">
-          <article className="surface-strong px-6 py-6 sm:px-8">
+        {/* Commercial stance + FAQ */}
+        <section className="mt-10 grid gap-5 lg:grid-cols-2">
+          <article className="surface-gradient px-6 py-6 lg:px-8">
             <p className="eyebrow">Commercial stance</p>
-            <h2 className="display-title mt-3 text-4xl sm:text-5xl">
-              Keep public code open. Keep operational leverage in the service.
+            <h2 className="mt-3 text-3xl font-bold text-white">
+              Open core. Operational leverage in the service.
             </h2>
-            <p className="mt-4 text-base leading-7 text-[var(--muted)]">
+            <p className="mt-4 text-[var(--foreground-secondary)]">
               The repository stays infrastructure-oriented and public-safe, while the
               hosted product compounds through indexing assets, tuning, and operator
-              workflows. Pricing should follow that same split.
+              workflows.
             </p>
           </article>
-          <article className="surface px-6 py-6 sm:px-8">
-            <p className="eyebrow">Frequently asked</p>
+
+          <article className="surface px-6 py-6 lg:px-8">
+            <p className="eyebrow">FAQ</p>
             <div className="mt-5 space-y-4">
               {pricingFaqs.map((item) => (
                 <div
                   key={item.question}
-                  className="rounded-[22px] border border-[var(--line)] bg-white/76 px-4 py-4"
+                  className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-4"
                 >
-                  <h3 className="text-lg font-semibold tracking-tight">{item.question}</h3>
-                  <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
+                  <h3 className="font-semibold text-white">{item.question}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-[var(--foreground-tertiary)]">
                     {item.answer}
                   </p>
                 </div>

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -15,19 +15,19 @@ export const metadata: Metadata = {
 
 export default function SignupPage() {
   return (
-    <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col px-5 pb-8 pt-5 sm:px-8 lg:px-10">
+    <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
       <SiteHeader currentPath="/signup" />
-      <main className="grid flex-1 gap-6 pb-8 pt-10 lg:grid-cols-[0.95fr_1.05fr]">
-        <section className="surface px-6 py-6 sm:px-8">
+      <main className="grid flex-1 gap-6 pb-8 pt-10 lg:grid-cols-2">
+        <section className="surface-elevated px-6 py-6 lg:px-8">
           <p className="eyebrow">Get started</p>
-          <h1 className="display-title mt-3 text-5xl sm:text-6xl">
+          <h1 className="mt-3 text-3xl font-bold text-white sm:text-4xl">
             Create a workspace for search, usage, and ingestion visibility.
           </h1>
-          <p className="mt-5 max-w-xl text-base leading-7 text-[var(--muted)]">
+          <p className="mt-5 max-w-xl text-[var(--foreground-secondary)]">
             The first phase keeps the setup intentionally small: create a workspace,
             mint an API key, inspect usage, and wire one demo surface into the API.
           </p>
-          <div className="mt-6 grid gap-3">
+          <div className="mt-6 grid gap-2">
             {[
               "Start with the free sandbox tier",
               "Use the same public API shape shown in the docs",
@@ -35,61 +35,62 @@ export default function SignupPage() {
             ].map((item) => (
               <div
                 key={item}
-                className="rounded-[22px] border border-[var(--line)] bg-white/76 px-4 py-4 text-sm leading-6"
+                className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground-secondary)]"
               >
+                <span className="h-1.5 w-1.5 rounded-full bg-[var(--success)]" />
                 {item}
               </div>
             ))}
           </div>
         </section>
-        <section className="surface px-6 py-6 sm:px-8">
-          <form className="rounded-[24px] border border-[var(--line)] bg-white/82 p-5">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-              Mock signup
+        <section className="surface-elevated px-6 py-6 lg:px-8">
+          <form className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5">
+            <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+              Create account
             </p>
             <div className="mt-5 grid gap-4 sm:grid-cols-2">
               <label className="block">
-                <span className="mb-2 block text-sm font-medium">First name</span>
+                <span className="mb-2 block text-sm font-medium text-[var(--foreground-secondary)]">First name</span>
                 <input
-                  className="h-12 w-full rounded-[18px] border border-[var(--line)] bg-transparent px-4 outline-none focus:border-[rgba(10,142,216,0.24)]"
+                  className="h-11 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 text-white outline-none transition-all placeholder:text-[var(--foreground-tertiary)] focus:border-[var(--brand)] focus:ring-1 focus:ring-[var(--brand)]"
                   type="text"
                   placeholder="Jessy"
                   autoComplete="given-name"
                 />
               </label>
               <label className="block">
-                <span className="mb-2 block text-sm font-medium">Last name</span>
+                <span className="mb-2 block text-sm font-medium text-[var(--foreground-secondary)]">Last name</span>
                 <input
-                  className="h-12 w-full rounded-[18px] border border-[var(--line)] bg-transparent px-4 outline-none focus:border-[rgba(10,142,216,0.24)]"
+                  className="h-11 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 text-white outline-none transition-all placeholder:text-[var(--foreground-tertiary)] focus:border-[var(--brand)] focus:ring-1 focus:ring-[var(--brand)]"
                   type="text"
                   placeholder="Tsui"
                   autoComplete="family-name"
                 />
               </label>
               <label className="block sm:col-span-2">
-                <span className="mb-2 block text-sm font-medium">Work email</span>
+                <span className="mb-2 block text-sm font-medium text-[var(--foreground-secondary)]">Work email</span>
                 <input
-                  className="h-12 w-full rounded-[18px] border border-[var(--line)] bg-transparent px-4 outline-none focus:border-[rgba(10,142,216,0.24)]"
+                  className="h-11 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 text-white outline-none transition-all placeholder:text-[var(--foreground-tertiary)] focus:border-[var(--brand)] focus:ring-1 focus:ring-[var(--brand)]"
                   type="email"
                   placeholder="you@company.com"
                   autoComplete="email"
                 />
               </label>
               <label className="block sm:col-span-2">
-                <span className="mb-2 block text-sm font-medium">Team goal</span>
-                <select className="h-12 w-full rounded-[18px] border border-[var(--line)] bg-transparent px-4 outline-none focus:border-[rgba(10,142,216,0.24)]">
+                <span className="mb-2 block text-sm font-medium text-[var(--foreground-secondary)]">Team goal</span>
+                <select className="h-11 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 text-white outline-none transition-all focus:border-[var(--brand)] focus:ring-1 focus:ring-[var(--brand)]">
                   <option>Evaluate b-roll demo search</option>
                   <option>Prototype knowledge retrieval</option>
                   <option>Prepare enterprise pilot</option>
                 </select>
               </label>
             </div>
-            <button type="submit" className="button-primary mt-6 w-full">
+            <button type="submit" className="button-accent mt-6 w-full">
               Create workspace
             </button>
-            <p className="mt-4 text-sm text-[var(--muted)]">
+            <p className="mt-4 text-sm text-[var(--foreground-tertiary)]">
               Already have an account?{" "}
-              <Link href="/login" className="font-semibold text-[var(--brand-deep)]">
+              <Link href="/login" className="font-medium text-[var(--brand-bright)] hover:underline">
                 Sign in
               </Link>
             </p>

--- a/frontend/components/agent-demo-console.tsx
+++ b/frontend/components/agent-demo-console.tsx
@@ -55,195 +55,231 @@ export function AgentDemoConsole() {
   }, []);
 
   return (
-    <section className="surface overflow-hidden px-5 py-5 sm:px-6 sm:py-6">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-            Live product rhythm
-          </p>
-          <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
-            Direct manipulation before prose.
-          </h2>
-        </div>
-        <span className="rounded-full border border-[var(--line)] bg-white/72 px-3 py-1 font-mono text-xs uppercase tracking-[0.16em] text-[var(--brand-deep)]">
-          Mock API wired
-        </span>
-      </div>
-
-      <div className="mt-5 flex flex-wrap gap-2">
-        {Object.entries(demoModes).map(([key, item]) => (
-          <button
-            key={key}
-            type="button"
-            className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
-              key === activeMode
-                ? "border-transparent bg-[var(--surface-dark)] text-white"
-                : "border-[var(--line)] bg-white/72 text-[var(--muted)]"
-            }`}
-            onClick={() => {
-              const nextMode = key as DemoMode;
-              const nextQuery = demoModes[nextMode].query;
-
-              startTransition(() => {
-                setActiveMode(nextMode);
-                setQuery(nextQuery);
-              });
-
-              void runPreview(nextMode, nextQuery);
-            }}
-          >
-            {item.label}
-          </button>
-        ))}
-      </div>
-
-      <form
-        className="mt-6 rounded-[26px] border border-[var(--line)] bg-white/82 p-4"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void runPreview(activeMode, query);
-        }}
-      >
-        <label className="font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
-          Query composer
-        </label>
-        <textarea
-          aria-label="Query composer"
-          className="mt-3 min-h-[120px] w-full resize-none rounded-[22px] border border-[var(--line)] bg-transparent px-4 py-4 text-base outline-none ring-0 placeholder:text-slate-400 focus:border-[rgba(10,142,216,0.25)]"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-        />
-        <div className="mt-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex flex-wrap gap-2">
-            {mode.tags.map((tag) => (
-              <span
-                key={tag}
-                className="rounded-full bg-slate-900/5 px-3 py-1 font-mono text-xs uppercase tracking-[0.14em] text-[var(--muted)]"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-          <div className="flex flex-col gap-3 sm:flex-row">
-            <Link href="/docs" className="button-secondary">
-              API shape
-            </Link>
-            <button type="submit" className="button-primary">
-              {isPending ? "Running preview" : "Run preview"}
-            </button>
-          </div>
-        </div>
-      </form>
-
-      <div className="mt-5 grid gap-4 sm:grid-cols-3">
-        <div className="rounded-[22px] border border-[var(--line)] bg-white/74 px-4 py-4">
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-            Surface
-          </p>
-          <p className="mt-3 text-lg font-semibold">{mode.surface}</p>
-        </div>
-        <div className="rounded-[22px] border border-[var(--line)] bg-white/74 px-4 py-4">
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-            Output
-          </p>
-          <p className="mt-3 text-lg font-semibold">{mode.output}</p>
-        </div>
-        <div className="rounded-[22px] border border-[var(--line)] bg-white/74 px-4 py-4">
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-            Active input
-          </p>
-          <p className="mt-3 line-clamp-2 text-sm leading-6 text-[var(--muted)]">
-            {deferredQuery}
-          </p>
-        </div>
-      </div>
-
-      <div className="mt-5 rounded-[26px] border border-[var(--line)] bg-white/78 p-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <section className="gradient-border overflow-hidden p-[1px]">
+      <div className="rounded-[15px] bg-[#0a0a0f] p-5 sm:p-6">
+        {/* Header */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-              Preview response
+            <p className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--brand-bright)]">
+              Interactive Demo
             </p>
-            <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
-              {response
-                ? `Request ${response.requestId} returned in ${response.latencyMs}ms.`
-                : "Running the first preview request."}
+            <h2 className="mt-2 text-xl font-bold text-white sm:text-2xl">
+              Try the API live
+            </h2>
+          </div>
+          <span className="badge badge-success w-fit">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-[var(--success)]" />
+            Mock API Connected
+          </span>
+        </div>
+
+        {/* Mode selector */}
+        <div className="mt-6 flex flex-wrap gap-2">
+          {Object.entries(demoModes).map(([key, item]) => (
+            <button
+              key={key}
+              type="button"
+              className={`rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
+                key === activeMode
+                  ? "border-[var(--brand)] bg-[var(--brand-subtle)] text-[var(--brand-bright)]"
+                  : "border-[var(--border)] bg-[var(--surface)] text-[var(--foreground-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+              }`}
+              onClick={() => {
+                const nextMode = key as DemoMode;
+                const nextQuery = demoModes[nextMode].query;
+
+                startTransition(() => {
+                  setActiveMode(nextMode);
+                  setQuery(nextQuery);
+                });
+
+                void runPreview(nextMode, nextQuery);
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Query composer */}
+        <form
+          className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void runPreview(activeMode, query);
+          }}
+        >
+          <label className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+            Query
+          </label>
+          <textarea
+            aria-label="Query composer"
+            className="mt-3 min-h-[100px] w-full resize-none rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-base text-white outline-none ring-0 transition-all placeholder:text-[var(--foreground-tertiary)] focus:border-[var(--brand)] focus:ring-1 focus:ring-[var(--brand)]"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <div className="mt-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap gap-2">
+              {mode.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-secondary)]"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Link href="/docs" className="button-secondary">
+                View API Docs
+              </Link>
+              <button type="submit" className="button-primary" disabled={isPending}>
+                {isPending ? (
+                  <>
+                    <svg
+                      className="h-4 w-4 animate-spin"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Running...
+                  </>
+                ) : (
+                  "Run Preview"
+                )}
+              </button>
+            </div>
+          </div>
+        </form>
+
+        {/* Info cards */}
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3">
+            <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+              Surface
+            </p>
+            <p className="mt-2 font-semibold text-white">{mode.surface}</p>
+          </div>
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3">
+            <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+              Output
+            </p>
+            <p className="mt-2 font-semibold text-white">{mode.output}</p>
+          </div>
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3">
+            <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+              Active Input
+            </p>
+            <p className="mt-2 line-clamp-2 text-sm text-[var(--foreground-secondary)]">
+              {deferredQuery}
             </p>
           </div>
+        </div>
+
+        {/* Response section */}
+        <div className="mt-5 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+                Response
+              </p>
+              <p className="mt-2 text-sm text-[var(--foreground-secondary)]">
+                {response
+                  ? `Request ${response.requestId} completed in ${response.latencyMs}ms`
+                  : "Running initial preview request..."}
+              </p>
+            </div>
+            {response ? (
+              <div className="flex flex-wrap gap-2 text-xs">
+                <span className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 font-mono text-[var(--foreground-secondary)]">
+                  {response.creditsUsed} credits
+                </span>
+                <span className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 font-mono text-[var(--foreground-secondary)]">
+                  {response.creditsRemaining} remaining
+                </span>
+              </div>
+            ) : null}
+          </div>
+
+          {error ? (
+            <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3">
+              <p className="text-sm text-red-400">{error}</p>
+            </div>
+          ) : null}
+
           {response ? (
-            <div className="flex flex-wrap gap-2 text-xs">
-              <span className="rounded-full bg-slate-900/5 px-3 py-1 font-mono uppercase tracking-[0.14em] text-[var(--muted)]">
-                {response.creditsUsed} credits
-              </span>
-              <span className="rounded-full bg-slate-900/5 px-3 py-1 font-mono uppercase tracking-[0.14em] text-[var(--muted)]">
-                {response.creditsRemaining} remaining
-              </span>
+            <div className="mt-5 grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+              <div className="space-y-3">
+                {response.answer ? (
+                  <div className="rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3">
+                    <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--brand-bright)]">
+                      Answer
+                    </p>
+                    <p className="mt-3 text-sm leading-relaxed text-white">
+                      {response.answer}
+                    </p>
+                  </div>
+                ) : null}
+
+                <div className="rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3">
+                  <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+                    Diagnostics
+                  </p>
+                  <ul className="mt-3 space-y-2 text-sm text-[var(--foreground-secondary)]">
+                    {response.diagnostics.map((item) => (
+                      <li key={item} className="flex items-center gap-2">
+                        <span className="h-1.5 w-1.5 rounded-full bg-[var(--brand)]" />
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                {response.results.map((result) => (
+                  <article
+                    key={result.id}
+                    className="rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-4 transition-all hover:border-[var(--border-strong)]"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-semibold text-white">{result.title}</p>
+                        <p className="mt-1 font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+                          {result.source}
+                        </p>
+                      </div>
+                      <span className="rounded-full bg-[var(--accent-subtle)] px-2.5 py-1 text-xs font-semibold text-[var(--accent-bright)]">
+                        {result.score}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-sm leading-relaxed text-[var(--foreground-secondary)]">
+                      {result.detail}
+                    </p>
+                    <div className="mt-4">
+                      <Link href={result.href as Route} className="button-ghost text-xs">
+                        Open guide →
+                      </Link>
+                    </div>
+                  </article>
+                ))}
+              </div>
             </div>
           ) : null}
         </div>
-
-        {error ? (
-          <p className="mt-4 rounded-[18px] bg-rose-100 px-4 py-3 text-sm text-rose-700">
-            {error}
-          </p>
-        ) : null}
-
-        {response ? (
-          <div className="mt-5 grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
-            <div className="space-y-4">
-              {response.answer ? (
-                <div className="rounded-[20px] border border-[var(--line)] bg-white/84 px-4 py-4">
-                  <p className="font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
-                    Model-facing answer
-                  </p>
-                  <p className="mt-3 text-sm leading-7 text-[var(--foreground)]">
-                    {response.answer}
-                  </p>
-                </div>
-              ) : null}
-
-              <div className="rounded-[20px] border border-[var(--line)] bg-white/84 px-4 py-4">
-                <p className="font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
-                  Diagnostics
-                </p>
-                <ul className="mt-3 space-y-2 text-sm leading-6 text-[var(--muted)]">
-                  {response.diagnostics.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-
-            <div className="space-y-3">
-              {response.results.map((result) => (
-                <article
-                  key={result.id}
-                  className="rounded-[20px] border border-[var(--line)] bg-white/84 px-4 py-4"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="text-lg font-semibold tracking-tight">{result.title}</p>
-                      <p className="mt-1 font-mono text-xs uppercase tracking-[0.16em] text-[var(--muted)]">
-                        {result.source}
-                      </p>
-                    </div>
-                    <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--accent)]">
-                      {result.score}
-                    </span>
-                  </div>
-                  <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-                    {result.detail}
-                  </p>
-                  <div className="mt-4">
-                    <Link href={result.href as Route} className="button-secondary">
-                      Open related guide
-                    </Link>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </div>
-        ) : null}
       </div>
     </section>
   );

--- a/frontend/components/ai-toolbar.tsx
+++ b/frontend/components/ai-toolbar.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+
+type AIToolbarProps = {
+  pageUrl?: string;
+  pageTitle?: string;
+  className?: string;
+  copyRootSelector?: string;
+};
+
+type OpenPlatform = "github" | "chatgpt" | "claude";
+
+interface OpenOption {
+  id: OpenPlatform;
+  label: string;
+  icon: React.ReactNode;
+  href: string;
+  accent: string;
+}
+
+export function AIToolbar({
+  pageUrl,
+  pageTitle = "Document",
+  className = "",
+  copyRootSelector,
+}: AIToolbarProps) {
+  const [copied, setCopied] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const copyTimeoutRef = useRef<number | null>(null);
+  const menuId = useId();
+
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+
+    const keyHandler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handler);
+    document.addEventListener("keydown", keyHandler);
+
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", keyHandler);
+
+      if (copyTimeoutRef.current) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const getFullUrl = () => {
+    const origin =
+      typeof window !== "undefined" ? window.location.origin : "https://cerul.ai";
+
+    return pageUrl ? new URL(pageUrl, origin).toString() : origin;
+  };
+
+  const fullUrl = getFullUrl();
+  const englishPrompt = encodeURIComponent(
+    `Read ${fullUrl} titled "${pageTitle}". I want to ask questions about it.`,
+  );
+
+  const openOptions: OpenOption[] = [
+    {
+      id: "github",
+      label: "Open in GitHub",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+      ),
+      href: "https://github.com/JessyTsui/cerul",
+      accent: "bg-slate-700 text-slate-100",
+    },
+    {
+      id: "chatgpt",
+      label: "Open in ChatGPT",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      ),
+      href: `https://chatgpt.com/?hints=search&q=${englishPrompt}`,
+      accent: "bg-emerald-500/20 text-emerald-400",
+    },
+    {
+      id: "claude",
+      label: "Open in Claude",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+        </svg>
+      ),
+      href: `https://claude.ai/new?q=${englishPrompt}`,
+      accent: "bg-amber-500/20 text-amber-400",
+    },
+  ];
+
+  const copyContent = async () => {
+    try {
+      const article = document.querySelector(
+        copyRootSelector || "[data-ai-copy-root='true'], article, main, [role='main']",
+      );
+      const safeTitle = pageTitle.trim() || "Document";
+      const clonedArticle =
+        article instanceof HTMLElement
+          ? (article.cloneNode(true) as HTMLElement)
+          : null;
+
+      clonedArticle?.querySelectorAll("[data-ai-copy-ignore='true']").forEach((node) => {
+        node.remove();
+      });
+
+      const textContent =
+        clonedArticle?.textContent
+          ?.replace(/[ \t]+\n/g, "\n")
+          .replace(/\n{3,}/g, "\n\n")
+          .trim() || "";
+      const content = textContent
+        ? `# ${safeTitle}\n\n${textContent}`
+        : fullUrl;
+
+      await navigator.clipboard.writeText(content);
+
+      setCopied(true);
+      if (copyTimeoutRef.current) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+
+      copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Silently fail
+    }
+  };
+
+  const handleOpen = (option: OpenOption) => {
+    window.open(option.href, "_blank", "noopener,noreferrer");
+    setMenuOpen(false);
+  };
+
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-2 ${className}`}
+      data-ai-copy-ignore="true"
+    >
+      <button
+        onClick={copyContent}
+        className="focus-ring inline-flex items-center gap-2 rounded-lg border border-[var(--accent)]/30 bg-[var(--accent-subtle)] px-3 py-2 text-sm font-medium text-[var(--accent-bright)] transition hover:bg-[var(--accent)]/20"
+        title="Copy page content"
+        type="button"
+      >
+        {copied ? (
+          <>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            Copied!
+          </>
+        ) : (
+          <>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            Copy
+          </>
+        )}
+      </button>
+
+      <div className="relative" ref={menuRef}>
+        <button
+          aria-controls={menuId}
+          aria-expanded={menuOpen}
+          aria-haspopup="menu"
+          type="button"
+          onClick={() => setMenuOpen((open) => !open)}
+          className="focus-ring inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm font-medium text-[var(--foreground-secondary)] transition hover:bg-[var(--surface-hover)]"
+        >
+          Open with AI
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+
+        {menuOpen && (
+          <div
+            className="absolute right-0 z-20 mt-2 w-56 rounded-xl border border-[var(--border)] bg-[var(--background-elevated)] p-2 shadow-xl"
+            id={menuId}
+            role="menu"
+          >
+            {openOptions.map((option) => (
+              <button
+                aria-label={option.label}
+                key={option.id}
+                type="button"
+                onClick={() => handleOpen(option)}
+                className="focus-ring flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium text-[var(--foreground-secondary)] transition hover:bg-[var(--surface)]"
+                role="menuitem"
+              >
+                <span className={`flex h-8 w-8 items-center justify-center rounded-full ${option.accent}`}>
+                  {option.icon}
+                </span>
+                <span>{option.label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/brand-mark.tsx
+++ b/frontend/components/brand-mark.tsx
@@ -2,12 +2,18 @@ import Link from "next/link";
 
 export function BrandMark() {
   return (
-    <Link href="/" className="inline-flex items-center gap-3">
-      <span className="relative flex h-11 w-11 items-center justify-center overflow-hidden rounded-[14px] border border-[var(--line)] bg-white/88 shadow-[0_18px_40px_rgba(16,33,45,0.12)]">
-        <span className="absolute inset-1 rounded-[10px] bg-[linear-gradient(135deg,rgba(10,142,216,0.88),rgba(255,107,44,0.95))]" />
-        <span className="relative text-lg font-semibold text-white">C</span>
+    <Link href="/" className="group inline-flex items-center gap-3">
+      <span className="relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-xl">
+        {/* Glow effect */}
+        <span className="absolute inset-0 bg-gradient-to-br from-blue-500 to-orange-500 opacity-80 transition-opacity group-hover:opacity-100" />
+        <span className="absolute inset-[1px] rounded-[11px] bg-[#0a0a0f]" />
+        {/* Inner gradient */}
+        <span className="absolute inset-[2px] rounded-[10px] bg-gradient-to-br from-blue-500 to-orange-500" />
+        <span className="relative text-lg font-bold text-white">C</span>
       </span>
-      <span className="display-title text-2xl">Cerul</span>
+      <span className="text-xl font-bold tracking-tight text-white">
+        Cerul
+      </span>
     </Link>
   );
 }

--- a/frontend/components/code-block.tsx
+++ b/frontend/components/code-block.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+
+type CodeBlockProps = {
+  code: string;
+  language?: string;
+  filename?: string;
+};
+
+export function CodeBlock({ code, language = "bash", filename }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const languageLabel = language.toUpperCase();
+
+  const copyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Silently fail
+    }
+  };
+
+  return (
+    <div className="code-window overflow-hidden">
+      <div className="code-window-header flex items-center justify-between">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="code-window-dot code-window-dot-red" />
+          <span className="code-window-dot code-window-dot-yellow" />
+          <span className="code-window-dot code-window-dot-green" />
+          <div className="ml-2 flex min-w-0 items-center gap-2">
+            {filename ? (
+              <span className="truncate font-mono text-xs text-[var(--foreground-tertiary)]">
+                {filename}
+              </span>
+            ) : null}
+            <span className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--foreground-tertiary)]">
+              {languageLabel}
+            </span>
+          </div>
+        </div>
+        <button
+          onClick={copyCode}
+          aria-label={copied ? "Code copied" : "Copy code sample"}
+          className="focus-ring flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-[var(--foreground-tertiary)] transition hover:bg-[var(--surface)] hover:text-[var(--foreground)]"
+          type="button"
+        >
+          {copied ? (
+            <>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              Copied
+            </>
+          ) : (
+            <>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+      <pre
+        className={`language-${language}`}
+        data-language={language}
+        tabIndex={0}
+      >
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/frontend/components/dashboard-live-status.tsx
+++ b/frontend/components/dashboard-live-status.tsx
@@ -46,51 +46,61 @@ export function DashboardLiveStatus({ initialStatus }: DashboardLiveStatusProps)
   }, []);
 
   return (
-    <div className="rounded-[22px] border border-[var(--line)] bg-white/76 px-4 py-4">
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-4">
       <div className="flex items-center justify-between gap-3">
-        <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
+        <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
           Live system state
         </p>
         <button
           type="button"
           onClick={() => void refreshStatus()}
-          className="rounded-full border border-[var(--line)] bg-white px-3 py-1 text-xs font-medium text-[var(--foreground)] transition hover:border-[rgba(10,142,216,0.24)]"
+          className="rounded-md border border-[var(--border)] bg-[var(--surface-elevated)] px-2.5 py-1 text-xs font-medium text-[var(--foreground-secondary)] transition hover:border-[var(--brand)] hover:text-[var(--foreground)]"
         >
-          {refreshing ? "Refreshing" : "Refresh"}
+          {refreshing ? (
+            <span className="flex items-center gap-1">
+              <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+              Refreshing
+            </span>
+          ) : (
+            "Refresh"
+          )}
         </button>
       </div>
       <div className="mt-4 flex items-center justify-between gap-3">
         <div>
-          <p className="text-lg font-semibold">{status.health}</p>
-          <p className="mt-1 text-sm leading-6 text-[var(--muted)]">
+          <p className="text-lg font-semibold text-white">{status.health}</p>
+          <p className="mt-1 text-sm text-[var(--foreground-tertiary)]">
             {status.summary}
           </p>
         </div>
         <span
-          className={`rounded-full px-3 py-1 text-xs font-semibold ${
+          className={`rounded-full px-2.5 py-1 text-xs font-medium ${
             status.health === "Healthy"
-              ? "bg-emerald-100 text-emerald-700"
-              : "bg-amber-100 text-amber-700"
+              ? "bg-emerald-500/15 text-emerald-400"
+              : "bg-amber-500/15 text-amber-400"
           }`}
         >
           {status.freshness}
         </span>
       </div>
       <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
-        <div className="rounded-[18px] bg-slate-900/4 px-3 py-3">
-          <p className="font-mono text-xs uppercase tracking-[0.14em] text-[var(--muted)]">
+        <div className="rounded-lg bg-[var(--surface-elevated)] px-3 py-3">
+          <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
             Active workers
           </p>
-          <p className="mt-2 text-xl font-semibold">{status.activeWorkers}</p>
+          <p className="mt-2 text-xl font-bold text-white">{status.activeWorkers}</p>
         </div>
-        <div className="rounded-[18px] bg-slate-900/4 px-3 py-3">
-          <p className="font-mono text-xs uppercase tracking-[0.14em] text-[var(--muted)]">
+        <div className="rounded-lg bg-[var(--surface-elevated)] px-3 py-3">
+          <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
             Queue depth
           </p>
-          <p className="mt-2 text-xl font-semibold">{status.queueDepth}</p>
+          <p className="mt-2 text-xl font-bold text-white">{status.queueDepth}</p>
         </div>
       </div>
-      <p className="mt-4 text-xs text-[var(--muted)]">Updated {status.updatedAt}</p>
+      <p className="mt-4 text-xs text-[var(--foreground-tertiary)]">Updated {status.updatedAt}</p>
     </div>
   );
 }

--- a/frontend/components/dashboard-shell.tsx
+++ b/frontend/components/dashboard-shell.tsx
@@ -23,32 +23,32 @@ export function DashboardShell({
   actions,
 }: DashboardShellProps) {
   return (
-    <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col px-5 pb-8 pt-5 sm:px-8 lg:px-10">
+    <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
       <SiteHeader currentPath={currentPath} />
-      <main className="flex-1 pb-8 pt-10">
-        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+      <main className="flex-1 pt-8">
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="eyebrow">Private console</p>
-            <h1 className="display-title mt-2 text-5xl sm:text-6xl">{title}</h1>
-            <p className="mt-4 max-w-3xl text-base leading-7 text-[var(--muted)] sm:text-lg">
+            <p className="eyebrow">Console</p>
+            <h1 className="mt-2 text-3xl font-bold text-white sm:text-4xl">{title}</h1>
+            <p className="mt-3 max-w-2xl text-[var(--foreground-secondary)]">
               {description}
             </p>
           </div>
-          <div className="flex flex-col gap-3 sm:flex-row">{actions}</div>
+          <div className="flex flex-wrap gap-3">{actions}</div>
         </div>
 
-        <section className="grid gap-6 xl:grid-cols-[300px_minmax(0,1fr)]">
-          <aside className="surface h-fit px-5 py-5">
-            <div className="rounded-[24px] bg-[var(--surface-dark)] px-4 py-4 text-white">
-              <p className="font-mono text-xs uppercase tracking-[0.18em] text-white/68">
+        <section className="grid gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+          <aside className="surface h-fit px-4 py-4">
+            <div className="rounded-xl bg-gradient-to-br from-[var(--brand)]/20 to-[var(--accent)]/10 px-4 py-4">
+              <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--brand-bright)]">
                 Workspace
               </p>
-              <p className="mt-3 text-2xl font-semibold">Cerul Sandbox</p>
-              <p className="mt-2 text-sm leading-6 text-white/68">
+              <p className="mt-2 text-xl font-bold text-white">Cerul Sandbox</p>
+              <p className="mt-1 text-sm text-[var(--foreground-secondary)]">
                 Shared platform for b-roll and knowledge search.
               </p>
             </div>
-            <nav className="mt-5 space-y-2">
+            <nav className="mt-4 space-y-1">
               {dashboardRoutes.map((item) => (
                 <Link
                   key={item.href}
@@ -60,16 +60,16 @@ export function DashboardShell({
                   }`}
                 >
                   <span>{item.label}</span>
-                  <span className="font-mono text-xs">{item.meta}</span>
+                  <span className="font-mono text-xs text-[var(--foreground-tertiary)]">{item.meta}</span>
                 </Link>
               ))}
             </nav>
-            <div className="mt-5">
+            <div className="mt-4">
               <DashboardLiveStatus initialStatus={snapshot.liveStatus} />
             </div>
           </aside>
 
-          <div className="space-y-6">{children}</div>
+          <div className="space-y-5">{children}</div>
         </section>
       </main>
     </div>

--- a/frontend/components/docs-card.tsx
+++ b/frontend/components/docs-card.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import type { Route } from "next";
+import type { ReactNode } from "react";
+
+type DocsCardProps = {
+  title: string;
+  description: string;
+  href?: Route;
+  icon?: ReactNode;
+  kicker?: string;
+  readingTime?: string;
+};
+
+export function DocsCard({
+  title,
+  description,
+  href,
+  icon,
+  kicker,
+  readingTime,
+}: DocsCardProps) {
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-3">
+          {icon ? (
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--border-brand)] bg-[var(--brand-subtle)] text-[var(--brand-bright)]">
+              {icon}
+            </div>
+          ) : null}
+          <div>
+            {kicker ? <p className="eyebrow text-[11px]">{kicker}</p> : null}
+            <h3 className="mt-2 font-semibold text-white">{title}</h3>
+          </div>
+        </div>
+        <span className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-xs text-[var(--foreground-tertiary)] transition group-hover:border-[var(--border-brand)] group-hover:text-[var(--brand-bright)]">
+          →
+        </span>
+      </div>
+      <p className="mt-4 text-sm leading-6 text-[var(--foreground-secondary)]">{description}</p>
+      <div className="mt-5 flex items-center justify-between gap-3 text-xs text-[var(--foreground-tertiary)]">
+        <span>{readingTime || "Guide"}</span>
+        {href ? <span className="text-[var(--brand-bright)]">Open guide</span> : null}
+      </div>
+    </>
+  );
+
+  const className =
+    "group block rounded-[20px] border border-[var(--border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] p-5 transition duration-200 hover:-translate-y-0.5 hover:border-[var(--border-brand)] hover:bg-[var(--surface-hover)] hover:shadow-[0_18px_40px_rgba(2,6,23,0.35)]";
+
+  if (href) {
+    return (
+      <Link href={href} className={className}>
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={className}>{content}</div>;
+}
+
+type DocsCardsProps = {
+  children: ReactNode;
+};
+
+export function DocsCards({ children }: DocsCardsProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {children}
+    </div>
+  );
+}

--- a/frontend/components/docs-sidebar.tsx
+++ b/frontend/components/docs-sidebar.tsx
@@ -1,68 +1,117 @@
+"use client";
+
 import type { Route } from "next";
 import Link from "next/link";
+import { useId, useState } from "react";
 import { getDocsIndexCards } from "@/lib/docs";
 
 type DocsSidebarProps = {
   currentSlug?: string;
-  anchors?: Array<{
-    href: string;
-    label: string;
-    index: string;
-  }>;
 };
 
-export function DocsSidebar({ currentSlug, anchors = [] }: DocsSidebarProps) {
+export function DocsSidebar({ currentSlug }: DocsSidebarProps) {
   const guides = getDocsIndexCards();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const panelId = useId();
+  const currentGuide = guides.find((guide) => guide.slug === currentSlug);
 
   return (
-    <aside className="surface sticky top-6 space-y-6 px-5 py-5">
-      <div>
-        <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-          Docs home
-        </p>
-        <Link href="/docs" className="dashboard-sidebar-link mt-3">
-          <span>Overview</span>
-          <span className="font-mono text-xs">00</span>
-        </Link>
-      </div>
+    <>
+      {/* Mobile toggle */}
+      <button
+        aria-controls={panelId}
+        aria-expanded={mobileOpen}
+        type="button"
+        onClick={() => setMobileOpen(!mobileOpen)}
+        className="focus-ring mb-4 flex w-full items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-left text-sm font-medium text-[var(--foreground-secondary)] lg:hidden"
+      >
+        <span className="flex items-center gap-2">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <line x1="4" y1="6" x2="20" y2="6" />
+            <line x1="4" y1="12" x2="20" y2="12" />
+            <line x1="4" y1="18" x2="20" y2="18" />
+          </svg>
+          Documentation menu
+        </span>
+        <span className="text-xs text-[var(--foreground-tertiary)]">
+          {currentGuide?.title || "Overview"}
+        </span>
+      </button>
 
-      <div>
-        <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-          Guides
-        </p>
-        <nav className="mt-3 space-y-2">
-          {guides.map((guide, index) => {
-            const active = currentSlug === guide.slug;
+      <aside className={`${mobileOpen ? "block" : "hidden"} lg:block`} id={panelId}>
+        <nav className="surface-elevated sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto p-4">
+          <div className="mb-4 border-b border-[var(--border)] pb-4">
+            <p className="eyebrow text-[11px]">Documentation</p>
+            <p className="mt-2 text-sm text-[var(--foreground-secondary)]">
+              {guides.length} guides plus API overview
+            </p>
+          </div>
 
-            return (
-              <Link
-                key={guide.slug}
-                href={guide.href as Route}
-                className={`dashboard-sidebar-link ${active ? "dashboard-sidebar-link-active" : ""}`}
-              >
-                <span>{guide.title}</span>
-                <span className="font-mono text-xs">{`0${index + 1}`}</span>
-              </Link>
-            );
-          })}
+          {/* Overview link */}
+          <Link
+            href="/docs"
+            className={`focus-ring mb-1 flex items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition ${
+              !currentSlug
+                ? "bg-[var(--brand-subtle)] text-[var(--brand-bright)]"
+                : "text-[var(--foreground-secondary)] hover:bg-[var(--surface)] hover:text-[var(--foreground)]"
+            }`}
+            onClick={() => setMobileOpen(false)}
+          >
+            <span>Overview</span>
+            <span className="font-mono text-xs text-[var(--foreground-tertiary)]">00</span>
+          </Link>
+
+          {/* Guides section */}
+          <div className="mt-4">
+            <p className="mb-2 px-3 font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+              Guides
+            </p>
+            <div className="space-y-1">
+              {guides.map((guide, index) => {
+                const active = currentSlug === guide.slug;
+
+                return (
+                  <Link
+                    key={guide.slug}
+                    href={guide.href as Route}
+                    className={`focus-ring flex items-center justify-between rounded-lg px-3 py-2 text-sm transition ${
+                      active
+                        ? "bg-[var(--brand-subtle)] text-[var(--brand-bright)]"
+                        : "text-[var(--foreground-secondary)] hover:bg-[var(--surface)] hover:text-[var(--foreground)]"
+                    }`}
+                    onClick={() => setMobileOpen(false)}
+                  >
+                    <span className="truncate">{guide.title}</span>
+                    <span className="ml-2 font-mono text-xs text-[var(--foreground-tertiary)]">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* API Reference */}
+          <div className="mt-4">
+            <p className="mb-2 px-3 font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+              Reference
+            </p>
+            <a
+              href="https://github.com/JessyTsui/cerul"
+              target="_blank"
+              rel="noreferrer"
+              className="focus-ring flex items-center justify-between rounded-lg px-3 py-2 text-sm text-[var(--foreground-secondary)] transition hover:bg-[var(--surface)] hover:text-[var(--foreground)]"
+            >
+              <span>GitHub Repository</span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          </div>
         </nav>
-      </div>
-
-      {anchors.length > 0 ? (
-        <div>
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-            On this page
-          </p>
-          <nav className="mt-3 space-y-2">
-            {anchors.map((anchor) => (
-              <a key={anchor.href} href={anchor.href} className="dashboard-sidebar-link">
-                <span>{anchor.label}</span>
-                <span className="font-mono text-xs">{anchor.index}</span>
-              </a>
-            ))}
-          </nav>
-        </div>
-      ) : null}
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/frontend/components/docs-tabs.tsx
+++ b/frontend/components/docs-tabs.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  useId,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+
+type TabItem = {
+  label: string;
+  value: string;
+  content: ReactNode;
+};
+
+type DocsTabsProps = {
+  items: TabItem[];
+  defaultValue?: string;
+};
+
+export function DocsTabs({ items, defaultValue }: DocsTabsProps) {
+  const initialTab =
+    defaultValue && items.some((item) => item.value === defaultValue)
+      ? defaultValue
+      : items[0]?.value ?? "";
+  const [activeTab, setActiveTab] = useState<string>(initialTab);
+  const tabsId = useId();
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
+      return;
+    }
+
+    event.preventDefault();
+
+    if (event.key === "Home") {
+      setActiveTab(items[0]?.value || "");
+      return;
+    }
+
+    if (event.key === "End") {
+      setActiveTab(items.at(-1)?.value || items[0]?.value || "");
+      return;
+    }
+
+    const direction = event.key === "ArrowRight" ? 1 : -1;
+    const nextIndex = (index + direction + items.length) % items.length;
+    setActiveTab(items[nextIndex]?.value || items[0]?.value || "");
+  };
+
+  return (
+    <div className="overflow-hidden rounded-[20px] border border-[var(--border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] shadow-[var(--shadow)]">
+      <div
+        aria-label="Code examples"
+        className="flex gap-1 overflow-x-auto border-b border-[var(--border)] px-3 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        role="tablist"
+      >
+        {items.map((item, index) => {
+          const selected = activeTab === item.value;
+          const tabId = `${tabsId}-${item.value}-tab`;
+          const panelId = `${tabsId}-${item.value}-panel`;
+
+          return (
+            <button
+              key={item.value}
+              onClick={() => setActiveTab(item.value)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              aria-controls={panelId}
+              aria-selected={selected}
+              className={`focus-ring rounded-full px-4 py-2 text-sm font-medium transition ${
+                selected
+                  ? "bg-[var(--brand-subtle)] text-[var(--brand-bright)] shadow-[inset_0_0_0_1px_var(--border-brand)]"
+                  : "text-[var(--foreground-tertiary)] hover:bg-[var(--surface)] hover:text-[var(--foreground)]"
+              }`}
+              id={tabId}
+              role="tab"
+              tabIndex={selected ? 0 : -1}
+              type="button"
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+      <div className="p-4">
+        {items.map((item) => (
+          <div
+            aria-labelledby={`${tabsId}-${item.value}-tab`}
+            hidden={activeTab !== item.value}
+            key={item.value}
+            id={`${tabsId}-${item.value}-panel`}
+            role="tabpanel"
+          >
+            {item.content}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/docs-toc.tsx
+++ b/frontend/components/docs-toc.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type TocItem = {
+  id: string;
+  text: string;
+  level: number;
+};
+
+type DocsTocProps = {
+  items: TocItem[];
+};
+
+export function DocsToc({ items }: DocsTocProps) {
+  const [activeId, setActiveId] = useState<string>(() => {
+    if (typeof window !== "undefined") {
+      return window.location.hash.slice(1) || items[0]?.id || "";
+    }
+
+    return items[0]?.id || "";
+  });
+
+  useEffect(() => {
+    if (items.length === 0) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((entryA, entryB) => entryA.boundingClientRect.top - entryB.boundingClientRect.top);
+
+        if (visibleEntries[0]) {
+          setActiveId(visibleEntries[0].target.id);
+        }
+      },
+      { rootMargin: "-96px 0px -70% 0px" }
+    );
+
+    items.forEach((item) => {
+      const element = document.getElementById(item.id);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      if (hash) {
+        setActiveId(hash);
+      }
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("hashchange", handleHashChange);
+    };
+  }, [items]);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Page table of contents"
+      className="surface-elevated sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto p-4"
+    >
+      <div className="mb-4 border-b border-[var(--border)] pb-4">
+        <p className="font-mono text-xs uppercase tracking-[0.1em] text-[var(--foreground-tertiary)]">
+          On this page
+        </p>
+        <p className="mt-2 text-sm text-[var(--foreground-secondary)]">
+          {items.length} sections
+        </p>
+      </div>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li key={item.id}>
+            <a
+              aria-current={activeId === item.id ? "location" : undefined}
+              href={`#${item.id}`}
+              className={`focus-ring block rounded-lg px-3 py-1.5 text-sm transition-colors ${
+                activeId === item.id
+                  ? "bg-[var(--brand-subtle)] text-[var(--brand-bright)] shadow-[inset_0_0_0_1px_var(--border-brand)]"
+                  : "text-[var(--foreground-tertiary)] hover:bg-[var(--surface)] hover:text-[var(--foreground)]"
+              }`}
+              style={{ paddingLeft: `${(item.level - 1) * 12 + 12}px` }}
+            >
+              {item.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/components/site-footer.tsx
+++ b/frontend/components/site-footer.tsx
@@ -2,44 +2,72 @@ import Link from "next/link";
 
 export function SiteFooter() {
   return (
-    <footer className="surface mt-10 px-6 py-6 sm:px-8">
-      <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
-        <div>
-          <p className="eyebrow">Build with public-safe primitives</p>
-          <h2 className="display-title mt-3 text-4xl sm:text-5xl">
-            Video understanding infrastructure that keeps the API thin.
+    <footer className="surface mt-20 px-6 py-8 sm:px-8">
+      <div className="grid gap-12 lg:grid-cols-[1.2fr_0.8fr] lg:items-end">
+        <div className="space-y-4">
+          <p className="eyebrow">Video understanding infrastructure</p>
+          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            Search what is shown in videos,
+            <br />
+            <span className="text-[var(--foreground-secondary)]">not just what is said.</span>
           </h2>
+          <p className="max-w-xl text-[var(--foreground-secondary)]">
+            Cerul turns slides, charts, demos, code screens, and whiteboards into
+            queryable evidence for AI agents.
+          </p>
         </div>
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-8 sm:grid-cols-2">
           <div>
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-              Explore
+            <p className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--foreground-tertiary)]">
+              Product
             </p>
-            <div className="mt-4 flex flex-col gap-3 text-sm">
-              <Link href="/">Home</Link>
-              <Link href="/docs">Docs</Link>
-              <Link href="/pricing">Pricing</Link>
-              <Link href="/dashboard">Dashboard</Link>
+            <div className="mt-4 flex flex-col gap-3">
+              <Link href="/" className="text-sm text-[var(--foreground-secondary)] transition-colors hover:text-white">
+                Home
+              </Link>
+              <Link href="/docs" className="text-sm text-[var(--foreground-secondary)] transition-colors hover:text-white">
+                Documentation
+              </Link>
+              <Link href="/pricing" className="text-sm text-[var(--foreground-secondary)] transition-colors hover:text-white">
+                Pricing
+              </Link>
+              <Link href="/dashboard" className="text-sm text-[var(--foreground-secondary)] transition-colors hover:text-white">
+                Dashboard
+              </Link>
             </div>
           </div>
           <div>
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--muted)]">
-              Repository
+            <p className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--foreground-tertiary)]">
+              Resources
             </p>
-            <div className="mt-4 flex flex-col gap-3 text-sm">
-              <a href="https://github.com/JessyTsui/cerul" target="_blank" rel="noreferrer">
+            <div className="mt-4 flex flex-col gap-3">
+              <a
+                href="https://github.com/JessyTsui/cerul"
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-[var(--foreground-secondary)] transition-colors hover:text-white"
+              >
                 GitHub
               </a>
-              <Link href="/login">Sign in</Link>
-              <a href="mailto:team@cerul.ai">team@cerul.ai</a>
-              <span className="text-[var(--muted)]">Apache 2.0</span>
+              <Link href="/login" className="text-sm text-[var(--foreground-secondary)] transition-colors hover:text-white">
+                Sign in
+              </Link>
+              <a
+                href="mailto:team@cerul.ai"
+                className="text-sm text-[var(--foreground-secondary)] transition-colors hover:text-white"
+              >
+                Contact
+              </a>
+              <span className="text-sm text-[var(--foreground-tertiary)]">
+                Apache 2.0 License
+              </span>
             </div>
           </div>
         </div>
       </div>
-      <div className="mt-8 flex flex-col gap-2 border-t border-[var(--line)] pt-5 text-sm text-[var(--muted)] sm:flex-row sm:items-center sm:justify-between">
-        <p>Search what is shown in videos, not just what is said.</p>
-        <p>Designed as one backbone for b-roll, knowledge, docs, and agent operations.</p>
+      <div className="mt-10 flex flex-col gap-4 border-t border-[var(--border)] pt-6 text-sm text-[var(--foreground-tertiary)] sm:flex-row sm:items-center sm:justify-between">
+        <p>© 2026 Cerul. All rights reserved.</p>
+        <p>Designed for AI agents and developer workflows.</p>
       </div>
     </footer>
   );

--- a/frontend/components/site-header.tsx
+++ b/frontend/components/site-header.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { useId, useState } from "react";
 import { BrandMark } from "@/components/brand-mark";
 import { isPrimaryNavigationActive, primaryNavigation } from "@/lib/site";
 
@@ -7,21 +10,55 @@ type SiteHeaderProps = {
 };
 
 export function SiteHeader({ currentPath }: SiteHeaderProps) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const navigationId = useId();
+  const actionsId = useId();
+
   return (
-    <header className="surface sticky top-5 z-20 px-4 py-4 sm:px-6">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <header className="sticky top-4 z-50 mx-auto max-w-[1400px] px-4">
+      <div className="surface-elevated flex flex-col gap-4 px-5 py-4 backdrop-blur-xl lg:flex-row lg:items-center lg:justify-between">
         <div className="flex items-center justify-between gap-4">
           <BrandMark />
-          <a
-            href="https://github.com/JessyTsui/cerul"
-            target="_blank"
-            rel="noreferrer"
-            className="button-secondary lg:hidden"
+          <button
+            type="button"
+            aria-controls={`${navigationId} ${actionsId}`}
+            aria-expanded={mobileMenuOpen}
+            className="button-ghost focus-ring lg:hidden"
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            aria-label="Toggle menu"
           >
-            GitHub
-          </a>
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              {mobileMenuOpen ? (
+                <>
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </>
+              ) : (
+                <>
+                  <line x1="4" y1="6" x2="20" y2="6" />
+                  <line x1="4" y1="12" x2="20" y2="12" />
+                  <line x1="4" y1="18" x2="20" y2="18" />
+                </>
+              )}
+            </svg>
+          </button>
         </div>
-        <nav className="flex flex-wrap items-center gap-x-5 gap-y-3">
+
+        <nav
+          id={navigationId}
+          className={`flex-col gap-4 lg:flex lg:flex-row lg:items-center ${
+            mobileMenuOpen ? "flex" : "hidden"
+          }`}
+        >
           {primaryNavigation.map((item) => {
             const isActive = isPrimaryNavigationActive(currentPath, item.href);
 
@@ -29,18 +66,41 @@ export function SiteHeader({ currentPath }: SiteHeaderProps) {
               <Link
                 key={item.label}
                 href={item.href}
-                className={`nav-link ${isActive ? "nav-link-active" : ""}`}
+                className={`nav-link px-2 ${isActive ? "nav-link-active" : ""}`}
+                onClick={() => setMobileMenuOpen(false)}
               >
                 {item.label}
               </Link>
             );
           })}
         </nav>
-        <div className="hidden items-center gap-3 lg:flex">
-          <Link href="/login" className="button-secondary">
+
+        <div
+          id={actionsId}
+          className={`flex-col gap-3 lg:flex lg:flex-row lg:items-center ${
+            mobileMenuOpen ? "flex" : "hidden"
+          }`}
+        >
+          <a
+            href="https://github.com/JessyTsui/cerul"
+            target="_blank"
+            rel="noreferrer"
+            className="button-ghost focus-ring inline-flex items-center gap-2"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+            >
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+            </svg>
+            GitHub
+          </a>
+          <Link href="/login" className="button-ghost focus-ring">
             Sign in
           </Link>
-          <Link href="/dashboard" className="button-primary">
+          <Link href="/dashboard" className="button-primary focus-ring">
             Console
           </Link>
         </div>

--- a/frontend/lib/demo-api.test.ts
+++ b/frontend/lib/demo-api.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getDashboardSnapshot, simulateDemoSearch } from "./demo-api";
+import {
+  getDashboardSnapshot,
+  simulateDemoSearch,
+  validateDemoSearchRequestBody,
+} from "./demo-api";
 
 describe("simulateDemoSearch", () => {
   it("returns deterministic knowledge search structure", () => {
@@ -11,6 +15,32 @@ describe("simulateDemoSearch", () => {
     expect(response.mode).toBe("knowledge");
     expect(response.results.length).toBeGreaterThan(0);
     expect(response.requestId.startsWith("req_")).toBe(true);
+  });
+});
+
+describe("validateDemoSearchRequestBody", () => {
+  it("accepts valid payloads and fills defaults", () => {
+    expect(validateDemoSearchRequestBody({ mode: "broll" })).toEqual({
+      ok: true,
+      value: {
+        mode: "broll",
+        query: "",
+      },
+    });
+  });
+
+  it("rejects invalid modes", () => {
+    expect(validateDemoSearchRequestBody({ mode: "foo" })).toEqual({
+      ok: false,
+      error: "Invalid demo mode.",
+    });
+  });
+
+  it("rejects non-string queries", () => {
+    expect(validateDemoSearchRequestBody({ query: 42 })).toEqual({
+      ok: false,
+      error: "Query must be a string.",
+    });
   });
 });
 

--- a/frontend/lib/demo-api.ts
+++ b/frontend/lib/demo-api.ts
@@ -23,6 +23,21 @@ export type DemoSearchResponse = {
   results: DemoSearchResult[];
 };
 
+export type DemoSearchInput = {
+  mode: DemoMode;
+  query: string;
+};
+
+export type DemoSearchRequestValidation =
+  | {
+      ok: true;
+      value: DemoSearchInput;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 export type OverviewCard = {
   label: string;
   value: string;
@@ -172,10 +187,49 @@ const templateResults: Record<DemoMode, Omit<DemoSearchResult, "score">[]> = {
   ],
 };
 
-export function simulateDemoSearch(input: {
-  mode: DemoMode;
-  query: string;
-}): DemoSearchResponse {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function validateDemoSearchRequestBody(
+  input: unknown,
+): DemoSearchRequestValidation {
+  if (!isPlainObject(input)) {
+    return {
+      ok: false,
+      error: "Request body must be a JSON object.",
+    };
+  }
+
+  const { mode, query } = input;
+
+  if (
+    mode !== undefined &&
+    (typeof mode !== "string" || !Object.hasOwn(demoModes, mode))
+  ) {
+    return {
+      ok: false,
+      error: "Invalid demo mode.",
+    };
+  }
+
+  if (query !== undefined && typeof query !== "string") {
+    return {
+      ok: false,
+      error: "Query must be a string.",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      mode: (mode as DemoMode | undefined) ?? "knowledge",
+      query: query ?? "",
+    },
+  };
+}
+
+export function simulateDemoSearch(input: DemoSearchInput): DemoSearchResponse {
   const normalizedQuery = input.query.trim() || demoModes[input.mode].query;
   const seed = hashString(`${input.mode}:${normalizedQuery}`);
   const latencyMs = 120 + (seed % 95);

--- a/frontend/lib/docs.test.ts
+++ b/frontend/lib/docs.test.ts
@@ -3,7 +3,7 @@ import { getDocBySlug, getDocsPageCanonical, getDocsStaticParams } from "./docs"
 
 describe("getDocBySlug", () => {
   it("returns the expected docs page", () => {
-    expect(getDocBySlug("quickstart")?.title).toBe("Quickstart");
+    expect(getDocBySlug("quickstart")?.title).toBe("Quickstart Guide");
   });
 
   it("returns undefined for unknown slugs", () => {

--- a/frontend/lib/docs.ts
+++ b/frontend/lib/docs.ts
@@ -5,6 +5,8 @@ export type DocSection = {
   body: string;
   bullets?: string[];
   code?: string;
+  language?: string;
+  filename?: string;
 };
 
 export type DocPage = {
@@ -16,209 +18,327 @@ export type DocPage = {
   sections: DocSection[];
 };
 
+// Base URL for API
+export const API_BASE_URL = "https://api.cerul.ai";
+
 export const docsNavigation = [
-  { href: "#surface", label: "Public surface", index: "01" },
-  { href: "#search", label: "Search endpoint", index: "02" },
-  { href: "#usage", label: "Usage endpoint", index: "03" },
-  { href: "#architecture", label: "Platform model", index: "04" },
-  { href: "#config", label: "Runtime config", index: "05" },
+  { href: "#introduction", label: "Introduction", index: "01" },
+  { href: "#authentication", label: "Authentication", index: "02" },
+  { href: "#search", label: "Search API", index: "03" },
+  { href: "#usage", label: "Usage API", index: "04" },
+  { href: "#response", label: "Response Format", index: "05" },
 ] as const;
 
 export const docsLandingSections = [
   {
-    id: "surface",
-    kicker: "Public surface",
-    title: "Start with the smallest stable contract.",
+    id: "introduction",
+    kicker: "Getting Started",
+    title: "Cerul API Overview",
     description:
-      "Cerul intentionally avoids a sprawling first release. The public API focuses on search and usage, while dashboard features stay on a private surface and ingestion remains worker-owned.",
+      "The Cerul API provides video understanding capabilities for AI agents. Search what is shown in videos, not just what is said. All API requests are made to the base URL with your API key included in the Authorization header.",
     list: [
-      "POST /v1/search for b-roll and knowledge retrieval",
-      "GET /v1/usage for tier and credit visibility",
-      "Dashboard-only endpoints stay private",
-      "Agent skills call the same HTTP surface as direct users",
+      "Base URL: https://api.cerul.ai",
+      "All requests require Bearer token authentication",
+      "JSON request and response bodies",
+      "UTF-8 encoding required",
     ],
     code: undefined,
+  },
+  {
+    id: "authentication",
+    kicker: "Authentication",
+    title: "API Key Authentication",
+    description:
+      "All API requests must include your API key in the Authorization header using the Bearer token format. You can create and manage API keys from your dashboard.",
+    list: [
+      "Include API key in every request",
+      "Use 'Authorization: Bearer YOUR_API_KEY' header",
+      "Keep your API keys secure",
+      "Rotate keys periodically from the dashboard",
+    ],
+    code: `curl "${API_BASE_URL}/v1/search" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
+  -H "Content-Type: application/json"`,
+    language: "bash",
+    filename: "auth.sh",
   },
   {
     id: "search",
-    kicker: "Search endpoint",
-    title: "One request shape, different retrieval behaviors.",
+    kicker: "Search Endpoint",
+    title: "POST /v1/search",
     description:
-      "Search stays structurally uniform even as the backing retrieval changes. B-roll returns asset-level matches, while knowledge search returns segment-level evidence and optional generated answers.",
+      "The search endpoint is the primary interface for retrieving video content. Use search_type to specify whether you want b-roll footage or knowledge segments. The endpoint returns matching results with metadata and direct video URLs.",
     list: [
-      "Consistent request envelope across tracks",
-      "Search type routes to the correct service internally",
-      "Failure does not spend credits",
-      "Result IDs are captured in query logs for later evaluation",
+      "search_type: 'broll' for stock footage",
+      "search_type: 'knowledge' for educational content",
+      "max_results: 1-50 (default: 10)",
+      "include_answer: true for AI-generated summaries",
     ],
-    code: `POST /v1/search
-
-{
-  "query": "sam altman agi timeline",
-  "search_type": "knowledge",
-  "max_results": 5,
-  "include_answer": true,
-  "filters": {
-    "speaker": "Sam Altman",
-    "published_after": "2023-01-01"
-  }
-}`,
+    code: `curl "${API_BASE_URL}/v1/search" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "cinematic drone shot of coastal highway at sunset",
+    "search_type": "broll",
+    "max_results": 5,
+    "filters": {
+      "min_duration": 5,
+      "max_duration": 30,
+      "source": "pexels"
+    }
+  }'`,
+    language: "bash",
+    filename: "search_broll.sh",
   },
   {
     id: "usage",
-    kicker: "Usage endpoint",
-    title: "Treat credits and rate limits as first-class product data.",
+    kicker: "Usage Endpoint",
+    title: "GET /v1/usage",
     description:
-      "Usage is not just billing plumbing. It is part of the operator experience, which is why the console and the public API should share the same underlying ledger and aggregation model.",
+      "Check your current usage, credit balance, and rate limits. This endpoint is useful for monitoring your consumption and preventing unexpected quota exhaustion.",
     list: [
-      "Credits limit and remaining balance",
-      "Active API key count",
-      "Monthly window visibility",
-      "Rate limit policy surfaced as product state",
+      "Returns current tier information",
+      "Shows credits used and remaining",
+      "Includes rate limit status",
+      "Real-time credit tracking",
     ],
-    code: `GET /v1/usage
-
-{
-  "tier": "free",
-  "period_start": "2026-03-01",
-  "period_end": "2026-03-31",
-  "credits_limit": 1000,
-  "credits_used": 128,
-  "credits_remaining": 872,
-  "rate_limit_per_sec": 1,
-  "api_keys_active": 1
+    code: `curl "${API_BASE_URL}/v1/usage" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY"`,
+    language: "bash",
+    filename: "usage.sh",
+  },
+  {
+    id: "response",
+    kicker: "Response Format",
+    title: "Understanding API Responses",
+    description:
+      "API responses follow a consistent JSON structure. Successful requests return HTTP 200 with result data. Errors return appropriate HTTP status codes with detailed error messages.",
+    list: [
+      "Results array contains video matches",
+      "Each result includes direct video URL",
+      "Score indicates relevance (0.0-1.0)",
+      "Metadata varies by search_type",
+    ],
+    code: `{
+  "results": [
+    {
+      "id": "pexels_28192743",
+      "score": 0.89,
+      "title": "Aerial drone shot of coastal highway",
+      "description": "Cinematic 4K drone footage of winding coastal road at golden hour",
+      "video_url": "https://videos.pexels.com/video-files/28192743/abc123.mp4",
+      "thumbnail_url": "https://images.pexels.com/photos/28192743/pexels-photo-28192743.jpeg",
+      "duration": 18,
+      "source": "pexels",
+      "license": "pexels-license"
+    }
+  ],
+  "credits_used": 1,
+  "credits_remaining": 999,
+  "request_id": "req_abc123xyz"
 }`,
-  },
-  {
-    id: "architecture",
-    kicker: "Platform model",
-    title: "Frontend stays presentational, workers keep the weight.",
-    description:
-      "The web app should explain, demo, and operate the system. It should not become the second business-logic core. Heavy media processing belongs in workers, and the API layer remains an orchestration plane.",
-    list: [
-      "Next.js for landing pages, docs, dashboard, and demo shells",
-      "FastAPI for auth, usage, routing, and thin orchestration",
-      "Python workers for ingestion, indexing, and media-heavy steps",
-      "Neon PostgreSQL + pgvector for usage and retrieval primitives",
-    ],
-    code: undefined,
-  },
-  {
-    id: "config",
-    kicker: "Runtime config",
-    title: "Public-safe defaults in YAML, secrets in environment.",
-    description:
-      "Frontend browser code should consume a derived public config subset. Raw secrets stay out of the browser and public-safe defaults stay versioned in config/*.yaml.",
-    list: [
-      "CERUL_ENV selects development or production profile",
-      "Public web and API URLs derive from config plus optional env overrides",
-      "Search tuning values should remain configurable, not hardcoded",
-      "Frontend should never read private repo config directly in browser code",
-    ],
-    code: `# Runtime profile
-CERUL_ENV=development
-
-# Optional public overrides
-API_BASE_URL=http://localhost:8000
-WEB_BASE_URL=http://localhost:3000`,
+    language: "json",
+    filename: "response.json",
   },
 ] as const;
 
 export const docsPages: DocPage[] = [
   {
     slug: "quickstart",
-    title: "Quickstart",
-    summary: "Get a local integration running with the smallest public setup.",
+    title: "Quickstart Guide",
+    summary: "Get up and running with the Cerul API in under 5 minutes. Learn how to make your first search request and understand the response format.",
     kicker: "Start here",
-    readingTime: "4 min read",
+    readingTime: "5 min read",
     sections: [
       {
-        title: "Environment shape",
+        title: "Get your API key",
         body:
-          "Cerul keeps public-safe defaults in versioned YAML and secrets in environment variables. The frontend should consume a derived public config subset, while API and worker runtimes read the full private configuration set.",
+          "Before making any requests, you need an API key. Sign up for a free account at cerul.ai and create your first API key from the dashboard. The free tier includes 1,000 credits to get started.",
         bullets: [
-          "Copy .env.example to .env",
-          "Set CERUL_ENV to development or production",
-          "Provide DATABASE_URL and provider keys outside public docs examples",
+          "Create account at https://cerul.ai",
+          "Navigate to Dashboard > API Keys",
+          "Click 'Create new key'",
+          "Copy your key (starts with 'cerul_')",
         ],
       },
       {
-        title: "First request",
+        title: "Make your first request",
         body:
-          "The first public integration path is direct HTTP. Keep the client thin, use API keys, and treat b-roll and knowledge as the same route with different search_type values.",
-        code: `curl "${"${CERUL_BASE_URL:-https://api.cerul.ai}"}/v1/search" \\
-  -H "Authorization: Bearer $CERUL_API_KEY" \\
+          "Use curl to make a test request. Replace YOUR_CERUL_API_KEY with your actual API key. This example searches for b-roll footage of coastal highways.",
+        code: `curl "${API_BASE_URL}/v1/search" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
-    "query": "cinematic drone shot of coastal highway at sunset",
+    "query": "cinematic drone shot of coastal highway",
     "search_type": "broll",
-    "max_results": 5
+    "max_results": 3
   }'`,
+        language: "bash",
+        filename: "first_request.sh",
       },
       {
-        title: "What comes next",
+        title: "Understanding the response",
         body:
-          "Once the search path is working, operators should move immediately to usage visibility, API key rotation, and demo instrumentation. Those surfaces share the same request and credit model.",
+          "The API returns a JSON object containing an array of results. Each result includes a direct video_url you can use to download or embed the video, along with metadata like duration, source, and relevance score.",
+        code: `{
+  "results": [
+    {
+      "id": "pexels_28192743",
+      "score": 0.89,
+      "title": "Aerial drone shot of coastal highway",
+      "video_url": "https://videos.pexels.com/video-files/28192743/abc123.mp4",
+      "thumbnail_url": "https://images.pexels.com/photos/28192743/pexels-photo-28192743.jpeg",
+      "duration": 18,
+      "source": "pexels"
+    }
+  ],
+  "credits_used": 1,
+  "credits_remaining": 999
+}`,
+        language: "json",
+        filename: "first_response.json",
+      },
+      {
+        title: "Using the video URL",
+        body:
+          "The video_url in the response is a direct link to the video file. You can use this URL to embed the video in your application, download it for processing, or serve it to your users. The URL is valid for 24 hours.",
+        bullets: [
+          "video_url: Direct link to MP4 file",
+          "thumbnail_url: Preview image",
+          "duration: Length in seconds",
+          "License info included for compliance",
+        ],
       },
     ],
   },
   {
     slug: "search-api",
-    title: "Search API",
-    summary: "Understand request shape, routing behavior, and response differences by track.",
-    kicker: "Public endpoint",
-    readingTime: "6 min read",
+    title: "Search API Reference",
+    summary: "Complete reference for the /v1/search endpoint. Learn about request parameters, filters, and response fields for both b-roll and knowledge searches.",
+    kicker: "API Reference",
+    readingTime: "8 min read",
     sections: [
       {
-        title: "One route, two tracks",
+        title: "Endpoint",
         body:
-          "Cerul exposes a single search entrypoint, but the underlying retrieval stack differs by track. B-roll resolves at the asset level, while knowledge resolves at segment granularity with optional answer generation.",
-        bullets: [
-          "Set search_type to broll for asset retrieval",
-          "Set search_type to knowledge for segment retrieval",
-          "Do not treat answer generation as mandatory for every request",
-        ],
+          "The search endpoint accepts POST requests with a JSON body containing your search parameters.",
+        code: `POST ${API_BASE_URL}/v1/search
+Content-Type: application/json
+Authorization: Bearer YOUR_CERUL_API_KEY`,
+        language: "http",
+        filename: "endpoint.http",
       },
       {
-        title: "Request example",
+        title: "Request parameters",
         body:
-          "The request envelope is intentionally stable. Filters may vary by track, but the core shape remains the same for clients and skills.",
+          "All search requests share a common structure. The search_type parameter determines which retrieval system to use.",
         code: `{
-  "query": "sam altman agi timeline",
-  "search_type": "knowledge",
-  "max_results": 5,
-  "include_answer": true,
-  "filters": {
-    "speaker": "Sam Altman",
-    "published_after": "2023-01-01"
+  "query": string,           // Required: Search query
+  "search_type": string,     // Required: "broll" or "knowledge"
+  "max_results": number,     // Optional: 1-50 (default: 10)
+  "include_answer": boolean, // Optional: AI summary (default: false)
+  "filters": {               // Optional: Track-specific filters
+    "min_duration": number,
+    "max_duration": number,
+    "source": string
   }
 }`,
+        language: "json",
+        filename: "request_params.json",
       },
       {
-        title: "Response contract",
+        title: "B-roll search example",
         body:
-          "Clients should expect result IDs, source URLs, and track-specific metadata. Knowledge results can include timestamps and answer text, while b-roll focuses on preview assets and descriptive metadata.",
+          "Search for stock footage and b-roll content. Results include direct video URLs from sources like Pexels and Pixabay.",
+        code: `curl "${API_BASE_URL}/v1/search" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "business handshake in modern office",
+    "search_type": "broll",
+    "max_results": 5,
+    "filters": {
+      "min_duration": 3,
+      "max_duration": 15
+    }
+  }'`,
+        language: "bash",
+        filename: "broll_search.sh",
+      },
+      {
+        title: "Knowledge search example",
+        body:
+          "Search educational and informational video content. Results include timestamps and optional AI-generated answers.",
+        code: `curl "${API_BASE_URL}/v1/search" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "sam altman explains the agi timeline",
+    "search_type": "knowledge",
+    "max_results": 5,
+    "include_answer": true,
+    "filters": {
+      "speaker": "Sam Altman",
+      "published_after": "2023-01-01"
+    }
+  }'`,
+        language: "bash",
+        filename: "knowledge_search.sh",
+      },
+      {
+        title: "Response fields",
+        body:
+          "The response contains an array of results, each with standardized fields and track-specific metadata.",
+        code: `{
+  "results": [{
+    "id": string,           // Unique result identifier
+    "score": number,        // Relevance score (0.0-1.0)
+    "title": string,        // Video title
+    "description": string,  // Video description
+    "video_url": string,    // Direct MP4 URL
+    "thumbnail_url": string,// Preview image
+    "duration": number,     // Length in seconds
+    "source": string,       // Content source
+
+    // B-roll specific:
+    "license": string,      // Usage license
+
+    // Knowledge specific:
+    "timestamp_start": number,
+    "timestamp_end": number,
+    "answer": string        // If include_answer: true
+  }],
+  "credits_used": number,
+  "credits_remaining": number,
+  "request_id": string
+}`,
+        language: "json",
+        filename: "response_fields.json",
       },
     ],
   },
   {
     slug: "usage-api",
-    title: "Usage API",
-    summary: "Expose credits, active keys, and rate limits as product-visible state.",
-    kicker: "Operational visibility",
+    title: "Usage API Reference",
+    summary: "Monitor your API consumption with the /v1/usage endpoint. Track credits, rate limits, and billing information.",
+    kicker: "API Reference",
     readingTime: "4 min read",
     sections: [
       {
-        title: "Why it exists",
+        title: "Check usage",
         body:
-          "Usage is a first-class operator surface, not a hidden billing detail. This endpoint keeps API clients and dashboard users aligned on one understanding of credits and limits.",
+          "The usage endpoint returns your current credit balance and consumption statistics. Use this to monitor your quota and prevent service interruption.",
+        code: `curl "${API_BASE_URL}/v1/usage" \\
+  -H "Authorization: Bearer YOUR_CERUL_API_KEY"`,
+        language: "bash",
+        filename: "check_usage.sh",
       },
       {
-        title: "Response example",
+        title: "Response format",
         body:
-          "The shape should remain simple enough for direct rendering in the dashboard and lightweight enough for programmatic polling.",
+          "The usage response includes your current tier, billing period, and credit information.",
         code: `{
-  "tier": "free",
+  "tier": "free",           // free, builder, or enterprise
   "period_start": "2026-03-01",
   "period_end": "2026-03-31",
   "credits_limit": 1000,
@@ -227,45 +347,72 @@ export const docsPages: DocPage[] = [
   "rate_limit_per_sec": 1,
   "api_keys_active": 1
 }`,
+        language: "json",
+        filename: "usage_response.json",
       },
       {
-        title: "Implementation note",
+        title: "Rate limiting",
         body:
-          "The same underlying ledger should power both dashboard analytics and public usage responses. Search success writes usage and query logs together, while failures do not spend credits.",
+          "API requests are rate-limited based on your tier. The rate_limit_per_sec field shows your current limit. Exceeding the limit returns HTTP 429.",
+        bullets: [
+          "Free tier: 1 request/second",
+          "Builder tier: 10 requests/second",
+          "Enterprise: Custom limits",
+          "Rate limit resets every second",
+        ],
       },
     ],
   },
   {
     slug: "architecture",
-    title: "Architecture",
-    summary: "Map the shared platform backbone across frontend, API, workers, and storage.",
-    kicker: "System model",
-    readingTime: "7 min read",
+    title: "System Architecture",
+    summary: "Understand how Cerul processes video search requests. Learn about our distributed architecture and data flow.",
+    kicker: "System Design",
+    readingTime: "6 min read",
     sections: [
       {
-        title: "Boundary discipline",
+        title: "Request flow",
         body:
-          "Cerul's product quality depends on not collapsing all logic into one surface. The frontend explains and operates the system, the API orchestrates requests, and workers own heavy ingestion and indexing.",
+          "When you make a search request, it travels through several components to deliver results. Understanding this flow helps optimize your integration.",
         bullets: [
-          "Next.js for public pages, docs, and dashboard surfaces",
-          "FastAPI for auth, usage, thin orchestration, and public responses",
-          "Python workers for ingestion, indexing, and media-heavy computation",
+          "1. API Gateway validates your API key",
+          "2. Query is parsed and routed to the correct search track",
+          "3. Vector search retrieves matching candidates",
+          "4. Results are ranked and formatted",
+          "5. Direct video URLs are generated",
+          "6. Response is returned with usage tracking",
         ],
       },
       {
-        title: "Shared retrieval foundation",
+        title: "B-roll vs Knowledge",
         body:
-          "B-roll and knowledge differ in workload shape, but they should share the same underlying platform services: auth, usage, storage, and retrieval abstractions.",
+          "The two search tracks use different indexing strategies and data sources, but share the same API interface.",
+        code: `B-roll Track:
+- Sources: Pexels, Pixabay (stock footage)
+- Indexing: CLIP visual embeddings
+- Results: Asset-level (entire video)
+- Metadata: License, duration, resolution
+
+Knowledge Track:
+- Sources: YouTube educational content
+- Indexing: Whisper + GPT-4o + CLIP
+- Results: Segment-level (timestamped clips)
+- Metadata: Speaker, transcript, timestamps`,
+        language: "text",
+        filename: "track_comparison.txt",
       },
       {
-        title: "Open-source boundary",
+        title: "Technology stack",
         body:
-          "Public code should remain reusable and infrastructure-oriented. Production indexes, prompts, tuned ranking parameters, and internal evaluation assets stay out of the repository.",
-        code: `frontend/   Next.js application
-backend/    FastAPI orchestration layer
-workers/    Ingestion and indexing pipelines
-db/         Public-safe migrations and seed artifacts
-skills/     Installable agent skills`,
+          "Cerul is built on modern infrastructure designed for scalability and reliability.",
+        bullets: [
+          "Frontend: Next.js 16 with React Server Components",
+          "API: FastAPI with async request handling",
+          "Database: Neon PostgreSQL with pgvector",
+          "Search: Vector similarity with HNSW indexing",
+          "Workers: Python for video processing and indexing",
+          "CDN: Global edge caching for video delivery",
+        ],
       },
     ],
   },
@@ -286,7 +433,7 @@ export function getDocsIndexCards() {
     summary: page.summary,
     kicker: page.kicker,
     readingTime: page.readingTime,
-    href: `/docs/${page.slug}`,
+    href: `/docs/${page.slug}` as const,
   }));
 }
 

--- a/frontend/lib/site.ts
+++ b/frontend/lib/site.ts
@@ -155,7 +155,7 @@ export const pricingTiers = [
   },
   {
     name: "Builder",
-    price: "$99",
+    price: "$20",
     cadence: "per month",
     description:
       "For teams building agent workflows that need predictable usage and more active keys.",
@@ -163,7 +163,7 @@ export const pricingTiers = [
     ctaHref: "/login",
     accent: "orange",
     features: [
-      "50,000 monthly credits",
+      "10,000 monthly credits",
       "5 active API keys",
       "Usage insights and search logs",
       "Priority email support",


### PR DESCRIPTION
## Summary

- refine the public docs experience with richer landing and detail layouts
- add reusable docs UI primitives for code samples, cards, tabs, TOC, and AI actions
- improve header/sidebar/mobile navigation polish across the frontend surfaces
- harden the demo search route with runtime request validation and update related tests

## Affected Directories

- `frontend/app`
- `frontend/components`
- `frontend/lib`
- `docs`

## Configuration Changes

- no new required environment variables
- existing optional frontend deployment variable remains `NEXT_PUBLIC_SITE_URL`

## Testing Status

- `pnpm --dir frontend lint`
- `pnpm --dir frontend test`
- `pnpm --dir frontend build`

## Screenshots

- not attached in this PR body
- verified locally in browser on `/docs` and `/docs/quickstart` for desktop and mobile layouts

## API Notes

Demo route validation now returns `400` for invalid payloads instead of surfacing runtime `500`s.

Example invalid request:

```http
POST /api/demo/search
Content-Type: application/json

{"mode":"foo","query":42}
```

Example response:

```json
{
  "error": "Invalid demo mode."
}
```
