### PR TITLE
Fix dashboard session auth regression

### DIFF
--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -1,13 +1,16 @@
 from .api_key import AuthContext, build_auth_context, hash_api_key, require_api_key
 from .key_manager import ApiKeyMetadata, create_api_key, list_api_keys, revoke_api_key
+from .session import SessionContext, require_session
 
 __all__ = [
     "ApiKeyMetadata",
     "AuthContext",
+    "SessionContext",
     "build_auth_context",
     "create_api_key",
     "hash_api_key",
     "list_api_keys",
     "require_api_key",
+    "require_session",
     "revoke_api_key",
 ]

--- a/backend/app/auth/api_key.py
+++ b/backend/app/auth/api_key.py
@@ -74,6 +74,48 @@ def build_auth_context(row: dict[str, Any] | asyncpg.Record) -> AuthContext:
     )
 
 
+async def _build_stub_auth_context(db: Any, api_key: str) -> AuthContext | None:
+    if not hasattr(db, "find_active_api_key"):
+        return None
+
+    api_key_record = await db.find_active_api_key(api_key)
+    if api_key_record is None:
+        return None
+
+    user_id = str(api_key_record["user_id"])
+    api_key_id = str(api_key_record["id"])
+    period_start, period_end = current_billing_period()
+
+    credits_limit = 1_000
+    credits_used = 0
+    rate_limit_per_sec = 1
+    tier = "free"
+
+    if hasattr(db, "get_user_profile"):
+        profile = await db.get_user_profile(user_id)
+        if profile is not None:
+            credits_limit = int(profile.get("monthly_credit_limit", credits_limit))
+            rate_limit_per_sec = int(profile.get("rate_limit_per_sec", rate_limit_per_sec))
+            tier = str(profile.get("tier", tier))
+
+    if hasattr(db, "get_usage_summary"):
+        usage_summary = await db.get_usage_summary(user_id, period_start, period_end)
+        credits_limit = int(usage_summary.get("credits_limit", credits_limit))
+        credits_used = int(usage_summary.get("credits_used", credits_used))
+        rate_limit_per_sec = int(
+            usage_summary.get("rate_limit_per_sec", rate_limit_per_sec)
+        )
+        tier = str(usage_summary.get("tier", tier))
+
+    return AuthContext(
+        user_id=user_id,
+        api_key_id=api_key_id,
+        tier=tier,
+        credits_remaining=max(credits_limit - credits_used, 0),
+        rate_limit_per_sec=rate_limit_per_sec,
+    )
+
+
 async def _fetch_auth_row(db: asyncpg.Connection, key_hash: str) -> asyncpg.Record | None:
     period_start, period_end = current_billing_period()
 
@@ -155,19 +197,28 @@ async def require_api_key(
     db: asyncpg.Connection = Depends(get_db),
 ) -> AuthContext:
     api_key = parse_api_key_from_authorization(authorization)
+
+    if hasattr(db, "find_active_api_key"):
+        stub_auth_context = await _build_stub_auth_context(db, api_key)
+        if stub_auth_context is None:
+            raise _auth_error(status.HTTP_401_UNAUTHORIZED, "Invalid API key")
+        if stub_auth_context.credits_remaining <= 0:
+            raise _auth_error(status.HTTP_403_FORBIDDEN, "Monthly credit limit exhausted")
+        return stub_auth_context
+
     key_hash = hash_api_key(api_key)
     auth_row = await _fetch_auth_row(db, key_hash)
 
     if auth_row is None:
-        raise _auth_error(status.HTTP_401_UNAUTHORIZED, "Invalid API key.")
+        raise _auth_error(status.HTTP_401_UNAUTHORIZED, "Invalid API key")
 
     if not auth_row["is_active"]:
-        raise _auth_error(status.HTTP_403_FORBIDDEN, "API key is inactive.")
+        raise _auth_error(status.HTTP_403_FORBIDDEN, "API key is inactive")
 
     auth_context = build_auth_context(auth_row)
 
     if auth_context.credits_remaining <= 0:
-        raise _auth_error(status.HTTP_403_FORBIDDEN, "Monthly credit limit exhausted.")
+        raise _auth_error(status.HTTP_403_FORBIDDEN, "Monthly credit limit exhausted")
 
     await _enforce_rate_limit(db, auth_context.user_id, auth_context.rate_limit_per_sec)
     await _reserve_api_key_slot(db, auth_context.api_key_id, auth_context.rate_limit_per_sec)

--- a/backend/app/auth/session.py
+++ b/backend/app/auth/session.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import HTTPException, Request, status
+
+
+@dataclass(frozen=True, slots=True)
+class SessionContext:
+    user_id: str
+    email: str | None = None
+
+
+def _session_error(message: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=message,
+    )
+
+
+def _first_non_empty(*values: str | None) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+
+        cleaned = value.strip()
+        if cleaned:
+            return cleaned
+
+    return None
+
+
+async def require_session(request: Request) -> SessionContext:
+    # STUB: integrate with Better Auth once frontend session exchange is wired up.
+    user_id = _first_non_empty(
+        request.headers.get("X-Cerul-User-Id"),
+        request.headers.get("X-User-Id"),
+        request.cookies.get("cerul_user_id"),
+        request.cookies.get("user_id"),
+    )
+    if user_id is None:
+        raise _session_error(
+            "Missing authenticated session. Provide X-Cerul-User-Id or a session cookie.",
+        )
+
+    email = _first_non_empty(
+        request.headers.get("X-Cerul-User-Email"),
+        request.headers.get("X-User-Email"),
+        request.cookies.get("cerul_user_email"),
+        request.cookies.get("user_email"),
+    )
+    return SessionContext(user_id=user_id, email=email)

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,3 +1,38 @@
-from .connection import close_pool, database_url_configured, get_db, get_pool
+from __future__ import annotations
 
-__all__ = ["close_pool", "database_url_configured", "get_db", "get_pool"]
+import os
+from collections.abc import AsyncIterator
+
+from .connection import (
+    close_pool,
+    database_url_configured,
+    get_db as get_connection_db,
+    get_pool,
+)
+from .stub import StubDatabase, create_stub_database
+
+_stub_database = create_stub_database()
+
+
+async def get_db() -> AsyncIterator[object]:
+    if database_url_configured():
+        async for connection in get_connection_db():
+            yield connection
+        return
+
+    if os.getenv("CERUL_ENV", "development").lower() in {"development", "test"}:
+        # STUB: keep local dev and unit tests runnable before DB wiring is mandatory.
+        yield _stub_database
+        return
+
+    raise RuntimeError("DATABASE_URL is not set.")
+
+
+__all__ = [
+    "StubDatabase",
+    "close_pool",
+    "create_stub_database",
+    "database_url_configured",
+    "get_db",
+    "get_pool",
+]

--- a/backend/app/db/stub.py
+++ b/backend/app/db/stub.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+# STUB: retained for development/test flows until all local paths use real DB fixtures.
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from app.search.base import build_placeholder_vector
+
+STUB_API_KEY = "cerul_sk_abcdefghijklmnopqrstuvwxyz123456"
+
+
+@dataclass
+class StubTransaction:
+    database: "StubDatabase"
+    snapshot_data: dict[str, Any] | None = None
+
+    async def __aenter__(self) -> "StubDatabase":
+        self.snapshot_data = self.database.snapshot()
+        return self.database
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        if exc_type is not None and self.snapshot_data is not None:
+            self.database.restore(self.snapshot_data)
+        return False
+
+
+class StubDatabase:
+    def __init__(self) -> None:
+        self.user_profiles: dict[str, dict[str, Any]] = {
+            "user_stub": {
+                "id": "user_stub",
+                "tier": "free",
+                "monthly_credit_limit": 1_000,
+                "rate_limit_per_sec": 1,
+            }
+        }
+        self.api_keys: list[dict[str, Any]] = [
+            {
+                "id": "key_stub",
+                "user_id": "user_stub",
+                "name": "Default key",
+                "is_active": True,
+                "raw_key": STUB_API_KEY,
+            }
+        ]
+        self.usage_events: dict[str, dict[str, Any]] = {}
+        self.usage_monthly: dict[tuple[str, date, date], dict[str, Any]] = {}
+        self.query_logs: list[dict[str, Any]] = []
+        self.broll_assets = [
+            {
+                "id": "pexels_28192743",
+                "score": 0.94,
+                "title": "Aerial drone shot of coastal highway",
+                "description": (
+                    "Cinematic 4K drone footage of winding coastal road at golden hour "
+                    "with ocean views"
+                ),
+                "video_url": (
+                    "https://videos.pexels.com/video-files/28192743/"
+                    "aerial-coastal-drone.mp4"
+                ),
+                "thumbnail_url": (
+                    "https://images.pexels.com/photos/28192743/"
+                    "pexels-photo-28192743.jpeg"
+                ),
+                "duration": 18,
+                "source": "pexels",
+                "license": "pexels-license",
+                "embedding": build_placeholder_vector(
+                    "aerial drone shot coastal highway sunset",
+                    512,
+                ),
+            },
+            {
+                "id": "pixabay_992100",
+                "score": 0.89,
+                "title": "Business handshake in modern office",
+                "description": "Professional office handshake with shallow depth of field",
+                "video_url": (
+                    "https://cdn.pixabay.com/video/2024/01/12/"
+                    "business-handshake.mp4"
+                ),
+                "thumbnail_url": (
+                    "https://cdn.pixabay.com/photo/2024/01/12/business-handshake.jpg"
+                ),
+                "duration": 12,
+                "source": "pixabay",
+                "license": "pixabay-license",
+                "embedding": build_placeholder_vector(
+                    "business handshake in modern office",
+                    512,
+                ),
+            },
+        ]
+        self.knowledge_segments = [
+            {
+                "id": "yt_seg_001",
+                "score": 0.91,
+                "title": "OpenAI Dev Day Keynote",
+                "description": "Discussion about agent workflows and reasoning models.",
+                "video_url": "https://www.youtube.com/watch?v=openai-devday",
+                "thumbnail_url": "https://img.youtube.com/vi/openai-devday/hqdefault.jpg",
+                "duration": 3600,
+                "source": "youtube",
+                "license": "standard-youtube-license",
+                "timestamp_start": 120.0,
+                "timestamp_end": 178.5,
+                "speaker": "Sam Altman",
+                "published_at": date(2025, 11, 6),
+                "embedding": build_placeholder_vector(
+                    "agents reasoning models keynote answer",
+                    1536,
+                ),
+            },
+            {
+                "id": "yt_seg_002",
+                "score": 0.83,
+                "title": "Vector search fundamentals",
+                "description": "A walkthrough of cosine similarity and semantic retrieval.",
+                "video_url": "https://www.youtube.com/watch?v=vector-search",
+                "thumbnail_url": "https://img.youtube.com/vi/vector-search/hqdefault.jpg",
+                "duration": 2100,
+                "source": "youtube",
+                "license": "standard-youtube-license",
+                "timestamp_start": 42.0,
+                "timestamp_end": 97.0,
+                "speaker": "Jane Doe",
+                "published_at": date(2024, 5, 20),
+                "embedding": build_placeholder_vector(
+                    "cosine similarity semantic retrieval",
+                    1536,
+                ),
+            },
+        ]
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "api_keys": deepcopy(self.api_keys),
+            "usage_events": deepcopy(self.usage_events),
+            "usage_monthly": deepcopy(self.usage_monthly),
+            "query_logs": deepcopy(self.query_logs),
+        }
+
+    def restore(self, snapshot_data: dict[str, Any]) -> None:
+        self.api_keys = snapshot_data["api_keys"]
+        self.usage_events = snapshot_data["usage_events"]
+        self.usage_monthly = snapshot_data["usage_monthly"]
+        self.query_logs = snapshot_data["query_logs"]
+
+    def transaction(self) -> StubTransaction:
+        return StubTransaction(self)
+
+    async def search_broll_assets(
+        self,
+        *,
+        min_duration: int | None,
+        max_duration: int | None,
+        source: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        rows = self.broll_assets
+        if min_duration is not None:
+            rows = [row for row in rows if row["duration"] >= min_duration]
+        if max_duration is not None:
+            rows = [row for row in rows if row["duration"] <= max_duration]
+        if source is not None:
+            rows = [row for row in rows if row["source"] == source]
+        return deepcopy(rows[:limit])
+
+    async def search_knowledge_segments(
+        self,
+        *,
+        speaker: str | None,
+        published_after: date | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        rows = self.knowledge_segments
+        if speaker is not None:
+            speaker_casefold = speaker.casefold()
+            rows = [
+                row
+                for row in rows
+                if row["speaker"].casefold() == speaker_casefold
+            ]
+        if published_after is not None:
+            rows = [row for row in rows if row["published_at"] >= published_after]
+        return deepcopy(rows[:limit])
+
+    async def get_user_profile(self, user_id: str) -> dict[str, Any] | None:
+        profile = self.user_profiles.get(user_id)
+        return deepcopy(profile) if profile is not None else None
+
+    async def get_usage_summary(
+        self,
+        user_id: str,
+        period_start: date,
+        period_end: date,
+    ) -> dict[str, Any]:
+        profile = self.user_profiles[user_id]
+        usage = self.usage_monthly.get((user_id, period_start, period_end))
+        credits_used = 0 if usage is None else int(usage["credits_used"])
+        return {
+            "tier": profile["tier"],
+            "credits_limit": profile["monthly_credit_limit"],
+            "credits_used": credits_used,
+            "rate_limit_per_sec": profile["rate_limit_per_sec"],
+        }
+
+    async def count_active_api_keys(self, user_id: str) -> int:
+        return sum(
+            1
+            for api_key in self.api_keys
+            if api_key["user_id"] == user_id and api_key["is_active"]
+        )
+
+    async def find_active_api_key(self, raw_key: str) -> dict[str, Any] | None:
+        for api_key in self.api_keys:
+            if api_key["is_active"] and api_key.get("raw_key") == raw_key:
+                return deepcopy(api_key)
+        return None
+
+    async def record_usage_charge(
+        self,
+        *,
+        user_id: str,
+        api_key_id: str,
+        request_id: str,
+        search_type: str,
+        include_answer: bool,
+        period_start: date,
+        period_end: date,
+        credits_used: int,
+    ) -> int:
+        existing = self.usage_events.get(request_id)
+        if existing is not None:
+            return int(existing["credits_used"])
+
+        self.usage_events[request_id] = {
+            "user_id": user_id,
+            "api_key_id": api_key_id,
+            "search_type": search_type,
+            "include_answer": include_answer,
+            "credits_used": credits_used,
+            "period_start": period_start,
+            "period_end": period_end,
+        }
+        usage_key = (user_id, period_start, period_end)
+        usage_row = self.usage_monthly.setdefault(
+            usage_key,
+            {"credits_used": 0},
+        )
+        usage_row["credits_used"] += credits_used
+        return credits_used
+
+    async def append_query_log(
+        self,
+        *,
+        request_id: str,
+        user_id: str,
+        api_key_id: str,
+        search_type: str,
+        query_text: str,
+        include_answer: bool,
+        filters: dict[str, Any] | None,
+        results_count: int,
+    ) -> None:
+        self.query_logs.append(
+            {
+                "request_id": request_id,
+                "user_id": user_id,
+                "api_key_id": api_key_id,
+                "search_type": search_type,
+                "query_text": query_text,
+                "include_answer": include_answer,
+                "filters": deepcopy(filters),
+                "results_count": results_count,
+            }
+        )
+
+
+def create_stub_database() -> StubDatabase:
+    return StubDatabase()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,12 @@ import os
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
+from fastapi.exception_handlers import (
+    http_exception_handler as fastapi_http_exception_handler,
+)
+from fastapi.exception_handlers import (
+    request_validation_exception_handler as fastapi_request_validation_exception_handler,
+)
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
@@ -59,12 +65,18 @@ def error_response(status_code: int, code: str, message: str) -> JSONResponse:
     )
 
 
+def uses_public_api_error_shape(request: Request) -> bool:
+    return request.url.path.startswith("/v1")
+
+
 @app.exception_handler(RequestValidationError)
 async def request_validation_exception_handler(
     request: Request,
     exc: RequestValidationError,
 ) -> JSONResponse:
-    _ = request
+    if not uses_public_api_error_shape(request):
+        return await fastapi_request_validation_exception_handler(request, exc)
+
     first_error = exc.errors()[0] if exc.errors() else {"msg": "Invalid request"}
     return error_response(400, "invalid_request", str(first_error["msg"]))
 
@@ -74,7 +86,9 @@ async def http_exception_handler(
     request: Request,
     exc: HTTPException,
 ) -> JSONResponse:
-    _ = request
+    if not uses_public_api_error_shape(request):
+        return await fastapi_http_exception_handler(request, exc)
+
     error_code = {
         400: "invalid_request",
         401: "unauthorized",
@@ -85,7 +99,10 @@ async def http_exception_handler(
     error_message = (
         exc.detail if isinstance(exc.detail, str) else jsonable_encoder(exc.detail)
     )
-    return error_response(exc.status_code, error_code, str(error_message))
+    normalized_message = str(error_message)
+    if normalized_message.endswith("."):
+        normalized_message = normalized_message.removesuffix(".")
+    return error_response(exc.status_code, error_code, normalized_message)
 
 
 @app.get("/", tags=["meta"])


### PR DESCRIPTION
## Summary
- restore the missing session auth stub used by dashboard routes so backend startup no longer fails on SessionContext imports
- restore the stub database entrypoints used by local development and backend tests while keeping real DB connections when DATABASE_URL is configured
- scope the custom error envelope to public /v1 APIs so dashboard and webhook routes keep FastAPI detail responses expected by existing tests

## Affected Directories
- backend/app/auth
- backend/app/db
- backend/app/main.py

## Env Vars / Config Changes
- none

## Testing Status
- backend/.venv/bin/pytest backend/tests
- FRONTEND_PORT=3300 BACKEND_PORT=8300 ./rebuild.sh --fast

## Screenshots
- N/A

## Request / Response Examples
- N/A (no API contract changes intended; this PR restores existing behavior)