### PR TITLE
Fix post-phase-1 merge bugs: missing import and workers test setup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/workers/conftest.py
+++ b/workers/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Add the repository root so cross-package imports like `backend.app.embedding`
+# resolve correctly when running workers tests.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))


### PR DESCRIPTION
## Summary
After merging the 4 Phase 1 PRs (#33 T03 Config, #35 T04 Stub DB cleanup, #34 T01 Gemini Embedding, #36 T02 Better Auth), validation found two bugs:

- **`backend/app/main.py`**: Missing `import os` caused `NameError` in `allowed_web_origins()` — the Better Auth PR added CORS origin logic using `os.getenv()` but didn't include the import
- **`workers/conftest.py`**: Workers tests failed with `ModuleNotFoundError: No module named 'backend'` — the Gemini Embedding PR introduced cross-package imports (`from backend.app.embedding import ...`) but workers had no `sys.path` setup to resolve them

## What the Phase 1 PRs delivered
- **#33 (T03)**: Layered config system (`base.yaml` + env file + env vars)
- **#35 (T04)**: Removed stub DB, all code paths use real PostgreSQL via docker-compose
- **#34 (T01)**: Migrated embeddings from CLIP (512d) to Gemini Embedding 2 (768d)
- **#36 (T02)**: Better Auth integration for real user registration/login/session

## Test plan
- [x] Frontend: lint, 37 tests, build all pass
- [x] Backend: 50 tests pass (with local PostgreSQL + migration 002)
- [x] Workers: 15 tests pass, 1 skipped (real API integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)