### PR TITLE
Implement knowledge reranking and answer generation

### DIFF
--- a/backend/app/search/answer.py
+++ b/backend/app/search/answer.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Mapping, Protocol, Sequence
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_ANSWER_MODEL = "gpt-4o"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class AnswerBackend(Protocol):
+    async def generate_answer(
+        self,
+        query: str,
+        segments: Sequence[Mapping[str, Any]],
+    ) -> str: ...
+
+
+class OpenAICompatibleAnswerBackend:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = DEFAULT_OPENAI_BASE_URL,
+        model_name: str = DEFAULT_ANSWER_MODEL,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.api_key = (api_key or os.getenv("OPENAI_API_KEY", "")).strip()
+        self.base_url = base_url.rstrip("/")
+        self.model_name = model_name
+        self.timeout_seconds = timeout_seconds
+
+    async def generate_answer(
+        self,
+        query: str,
+        segments: Sequence[Mapping[str, Any]],
+    ) -> str:
+        if not self.api_key:
+            raise RuntimeError("OPENAI_API_KEY is not set.")
+
+        prompt = build_answer_prompt(query=query, segments=segments)
+        payload = {
+            "model": self.model_name,
+            "temperature": 0.2,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You answer knowledge search queries using only the provided video "
+                        "segments. Cite claims inline with timestamp references in the exact "
+                        "format [Video Title, m:ss-m:ss] or [Video Title, h:mm:ss-h:mm:ss]."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(
+                f"{self.base_url}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+
+        response.raise_for_status()
+        response_payload = response.json()
+        content = _extract_message_content(response_payload).strip()
+        if not content:
+            raise ValueError("Answer generation returned an empty response.")
+        return content
+
+
+class AnswerGenerator:
+    def __init__(
+        self,
+        *,
+        backend: AnswerBackend | None = None,
+    ) -> None:
+        self.backend = backend or OpenAICompatibleAnswerBackend()
+
+    async def generate(
+        self,
+        query: str,
+        segments: Sequence[Mapping[str, Any]],
+    ) -> str | None:
+        if not segments:
+            return None
+
+        try:
+            return await self.backend.generate_answer(query, segments)
+        except Exception as exc:
+            logger.warning("Knowledge answer generation failed: %s", exc)
+            return None
+
+
+def build_answer_prompt(
+    *,
+    query: str,
+    segments: Sequence[Mapping[str, Any]],
+) -> str:
+    segment_blocks = []
+    for index, segment in enumerate(segments, start=1):
+        segment_blocks.append(
+            "\n".join(
+                [
+                    f"Segment {index}:",
+                    f"Video title: {_coerce_text(segment.get('title')) or 'Untitled video'}",
+                    f"Segment title: {_coerce_text(segment.get('segment_title')) or 'Untitled segment'}",
+                    f"Speaker: {_coerce_text(segment.get('speaker')) or 'Unknown speaker'}",
+                    (
+                        "Timestamp range: "
+                        f"{_format_timestamp_range(segment.get('timestamp_start'), segment.get('timestamp_end'))}"
+                    ),
+                    "Transcript:",
+                    _truncate_text(_coerce_text(segment.get("transcript_text")), limit=3000)
+                    or "N/A",
+                    "Visual description:",
+                    _truncate_text(
+                        _coerce_text(segment.get("visual_summary") or segment.get("description")),
+                        limit=1200,
+                    )
+                    or "N/A",
+                ]
+            )
+        )
+
+    joined_segments = "\n\n".join(segment_blocks)
+    return (
+        "User query:\n"
+        f"{query}\n\n"
+        "Retrieved evidence segments:\n"
+        f"{joined_segments}\n\n"
+        "Write a concise synthesized answer grounded only in these segments.\n"
+        "Every factual claim must include at least one timestamp citation.\n"
+        "If the evidence is incomplete, say that explicitly instead of guessing."
+    )
+
+
+def _extract_message_content(payload: Mapping[str, Any]) -> str:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("LLM response did not include choices.")
+
+    first_choice = choices[0]
+    if not isinstance(first_choice, Mapping):
+        raise ValueError("LLM choice payload is malformed.")
+
+    message = first_choice.get("message")
+    if not isinstance(message, Mapping):
+        raise ValueError("LLM response did not include a message.")
+
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        text_fragments = []
+        for item in content:
+            if isinstance(item, Mapping) and isinstance(item.get("text"), str):
+                text_fragments.append(item["text"])
+        joined_content = "".join(text_fragments).strip()
+        if joined_content:
+            return joined_content
+
+    raise ValueError("LLM response did not include message content.")
+
+
+def _format_timestamp_range(start: Any, end: Any) -> str:
+    return f"{_format_timestamp(start)}-{_format_timestamp(end)}"
+
+
+def _format_timestamp(value: Any) -> str:
+    total_seconds = max(int(float(value or 0.0)), 0)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes}:{seconds:02d}"
+
+
+def _coerce_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _truncate_text(value: str, *, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3].rstrip() + "..."

--- a/backend/app/search/knowledge.py
+++ b/backend/app/search/knowledge.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
+import time
 from typing import Any, Sequence
 
 from app.embedding.base import EmbeddingBackend
 from app.embedding.gemini import GeminiEmbeddingBackend
+from app.search.answer import AnswerGenerator
 from app.search.base import (
     DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
     mmr_diversify,
@@ -13,6 +16,9 @@ from app.search.base import (
     vector_to_literal,
 )
 from app.search.models import KnowledgeFilters, KnowledgeResult, SearchRequest
+from app.search.rerank import LLMReranker
+
+logger = logging.getLogger(__name__)
 
 
 class KnowledgeSearchService:
@@ -21,10 +27,14 @@ class KnowledgeSearchService:
         db: Any,
         *,
         embedding_backend: EmbeddingBackend | None = None,
+        reranker: LLMReranker | None = None,
+        answer_generator: AnswerGenerator | None = None,
         mmr_lambda: float | None = None,
     ) -> None:
         self.db = db
         self.embedding_backend = embedding_backend or GeminiEmbeddingBackend()
+        self.reranker = reranker or LLMReranker()
+        self.answer_generator = answer_generator or AnswerGenerator()
         self.mmr_lambda = resolve_mmr_lambda(mmr_lambda)
 
     def build_query(
@@ -49,7 +59,10 @@ class KnowledgeSearchService:
             SELECT
                 ks.id::text AS id,
                 kv.title,
+                ks.title AS segment_title,
                 ks.description,
+                ks.transcript_text,
+                ks.visual_summary,
                 kv.video_url,
                 kv.thumbnail_url,
                 kv.duration_seconds AS duration,
@@ -84,17 +97,30 @@ class KnowledgeSearchService:
         )
         sql, params = self.build_query(request, resolved_query_vector)
         rows = await self._fetch_rows(request, sql, params)
-        rows = self._placeholder_rerank(rows)
-        results = [self._row_to_result(request, row) for row in rows]
-        embeddings = [parse_vector(row.get("embedding")) for row in rows]
-        relevance_scores = [float(row.get("score", 0.0)) for row in rows]
-        return mmr_diversify(
-            results,
-            embeddings,
-            limit=request.max_results,
-            lambda_multiplier=self.mmr_lambda,
-            relevance_scores=relevance_scores,
+        if not rows:
+            return []
+
+        rerank_started_at = time.perf_counter()
+        reranked_rows = await self.reranker.rerank(request.query, rows)
+        logger.info(
+            "Reranked %d knowledge candidates in %.2f ms",
+            min(len(rows), getattr(self.reranker, "top_n", len(rows))),
+            (time.perf_counter() - rerank_started_at) * 1000,
         )
+
+        selected_rows = self._diversify_rows(reranked_rows, limit=request.max_results)
+
+        answer: str | None = None
+        if request.include_answer and selected_rows:
+            answer_started_at = time.perf_counter()
+            answer = await self.answer_generator.generate(request.query, selected_rows)
+            logger.info(
+                "Generated knowledge answer from %d segments in %.2f ms",
+                len(selected_rows),
+                (time.perf_counter() - answer_started_at) * 1000,
+            )
+
+        return [self._row_to_result(row, answer=answer) for row in selected_rows]
 
     async def _fetch_rows(
         self,
@@ -104,27 +130,34 @@ class KnowledgeSearchService:
     ) -> list[dict[str, Any]]:
         return list(await self.db.fetch(sql, *params))
 
-    def _placeholder_rerank(self, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return sorted(rows, key=lambda row: row.get("score", 0.0), reverse=True)
-
-    def _placeholder_answer(self, query: str, row: dict[str, Any]) -> str:
-        return (
-            f"Potential answer for '{query}' based on {row['title']} "
-            f"from {row['timestamp_start']:.0f}s to {row['timestamp_end']:.0f}s."
+    def _diversify_rows(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        embeddings = [parse_vector(row.get("embedding")) for row in rows]
+        relevance_scores = [
+            float(row.get("rerank_score", row.get("score", 0.0)))
+            for row in rows
+        ]
+        return mmr_diversify(
+            rows,
+            embeddings,
+            limit=limit,
+            lambda_multiplier=self.mmr_lambda,
+            relevance_scores=relevance_scores,
         )
 
     def _row_to_result(
         self,
-        request: SearchRequest,
         row: dict[str, Any],
+        *,
+        answer: str | None = None,
     ) -> KnowledgeResult:
-        answer: str | None = None
-        if request.include_answer:
-            answer = self._placeholder_answer(request.query, row)
-
         return KnowledgeResult(
             id=row["id"],
-            score=max(float(row["score"]), 0.0),
+            score=max(float(row.get("rerank_score", row.get("score", 0.0))), 0.0),
             title=row["title"],
             description=row["description"],
             video_url=row["video_url"],

--- a/backend/app/search/rerank.py
+++ b/backend/app/search/rerank.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Mapping, Protocol, Sequence
+
+import httpx
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_RERANK_MODEL = "gpt-4o-mini"
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+
+class RerankerBackend(Protocol):
+    async def score_relevance(
+        self,
+        query: str,
+        candidate: Mapping[str, Any],
+    ) -> float: ...
+
+
+class OpenAICompatibleRerankerBackend:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = DEFAULT_OPENAI_BASE_URL,
+        model_name: str = DEFAULT_RERANK_MODEL,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        prompt_template: str | None = None,
+    ) -> None:
+        settings = get_settings()
+        self.api_key = (api_key or os.getenv("OPENAI_API_KEY", "")).strip()
+        self.base_url = base_url.rstrip("/")
+        self.model_name = model_name
+        self.timeout_seconds = timeout_seconds
+        self.prompt_template = prompt_template or settings.knowledge.rerank_prompt_template
+
+    async def score_relevance(
+        self,
+        query: str,
+        candidate: Mapping[str, Any],
+    ) -> float:
+        if not self.api_key:
+            raise RuntimeError("OPENAI_API_KEY is not set.")
+
+        prompt = build_rerank_prompt(
+            query=query,
+            candidate=candidate,
+            template_name=self.prompt_template,
+        )
+        payload = {
+            "model": self.model_name,
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You score how relevant a video segment is to a search query. "
+                        "Return JSON with a single numeric field named score from 0 to 10."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(
+                f"{self.base_url}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+
+        response.raise_for_status()
+        response_payload = response.json()
+        content = _extract_message_content(response_payload)
+        parsed_content = json.loads(content)
+        if not isinstance(parsed_content, dict) or "score" not in parsed_content:
+            raise ValueError("Reranker response did not include a score field.")
+
+        return _clamp_llm_score(float(parsed_content["score"]))
+
+
+class LLMReranker:
+    def __init__(
+        self,
+        *,
+        backend: RerankerBackend | None = None,
+        top_n: int | None = None,
+    ) -> None:
+        settings = get_settings()
+        self.backend = backend or OpenAICompatibleRerankerBackend()
+        self.top_n = top_n or settings.knowledge.rerank_top_n
+
+    async def rerank(
+        self,
+        query: str,
+        candidates: Sequence[Mapping[str, Any]],
+        top_n: int | None = None,
+    ) -> list[dict[str, Any]]:
+        if not candidates:
+            return []
+
+        candidate_limit = min(top_n or self.top_n, len(candidates))
+        rerank_candidates = [dict(candidate) for candidate in candidates[:candidate_limit]]
+        remaining_candidates = [dict(candidate) for candidate in candidates[candidate_limit:]]
+
+        try:
+            llm_scores = await asyncio.gather(
+                *[
+                    self.backend.score_relevance(query, candidate)
+                    for candidate in rerank_candidates
+                ]
+            )
+        except Exception as exc:
+            logger.warning(
+                "Knowledge reranking failed; falling back to vector score ordering: %s",
+                exc,
+            )
+            return sorted(
+                [dict(candidate) for candidate in candidates],
+                key=lambda candidate: float(candidate.get("score", 0.0)),
+                reverse=True,
+            )
+
+        scored_candidates: list[tuple[dict[str, Any], float, int]] = []
+        for index, (candidate, llm_score) in enumerate(zip(rerank_candidates, llm_scores)):
+            normalized_score = max(0.0, min(llm_score / 10.0, 1.0))
+            candidate["llm_score"] = llm_score
+            candidate["rerank_score"] = normalized_score
+            scored_candidates.append((candidate, normalized_score, index))
+
+        scored_candidates.sort(key=lambda item: (-item[1], item[2]))
+        ordered_candidates = [candidate for candidate, _, _ in scored_candidates]
+        return ordered_candidates + remaining_candidates
+
+
+def build_rerank_prompt(
+    *,
+    query: str,
+    candidate: Mapping[str, Any],
+    template_name: str = "default",
+) -> str:
+    transcript_text = _truncate_text(
+        _coerce_text(candidate.get("transcript_text") or candidate.get("description")),
+        limit=2500,
+    )
+    visual_description = _truncate_text(
+        _coerce_text(candidate.get("visual_summary") or candidate.get("description")),
+        limit=1000,
+    )
+    video_title = _coerce_text(candidate.get("title"))
+    speaker = _coerce_text(candidate.get("speaker")) or "Unknown speaker"
+    segment_title = _coerce_text(candidate.get("segment_title"))
+
+    if template_name != "default":
+        logger.debug("Unknown rerank prompt template '%s'; using default.", template_name)
+
+    return (
+        "Search query:\n"
+        f"{query}\n\n"
+        "Candidate segment:\n"
+        f"Video title: {video_title or 'Untitled video'}\n"
+        f"Segment title: {segment_title or 'Untitled segment'}\n"
+        f"Speaker: {speaker}\n"
+        f"Transcript:\n{transcript_text or 'N/A'}\n\n"
+        f"Visual description:\n{visual_description or 'N/A'}\n\n"
+        "Score how useful this segment is for answering the search query.\n"
+        "Use 0 for irrelevant and 10 for highly relevant evidence.\n"
+        'Return JSON only, for example: {"score": 8.5}.'
+    )
+
+
+def _extract_message_content(payload: Mapping[str, Any]) -> str:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("LLM response did not include choices.")
+
+    first_choice = choices[0]
+    if not isinstance(first_choice, Mapping):
+        raise ValueError("LLM choice payload is malformed.")
+
+    message = first_choice.get("message")
+    if not isinstance(message, Mapping):
+        raise ValueError("LLM response did not include a message.")
+
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        text_fragments = []
+        for item in content:
+            if isinstance(item, Mapping) and isinstance(item.get("text"), str):
+                text_fragments.append(item["text"])
+        joined_content = "".join(text_fragments).strip()
+        if joined_content:
+            return joined_content
+
+    raise ValueError("LLM response did not include message content.")
+
+
+def _clamp_llm_score(score: float) -> float:
+    return max(0.0, min(score, 10.0))
+
+
+def _coerce_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _truncate_text(value: str, *, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3].rstrip() + "..."

--- a/backend/tests/test_search_services.py
+++ b/backend/tests/test_search_services.py
@@ -2,9 +2,11 @@ import asyncio
 import logging
 
 import pytest
+import httpx
 
 from app.routers.search import resolve_search_service
 from app.search.broll import BrollSearchService
+from app.search.answer import AnswerGenerator, OpenAICompatibleAnswerBackend
 from app.search import resolve_mmr_lambda
 from app.search.base import (
     DEFAULT_BROLL_VECTOR_DIMENSION,
@@ -14,6 +16,7 @@ from app.search.base import (
 )
 from app.search.knowledge import KnowledgeSearchService
 from app.search.models import SearchRequest
+from app.search.rerank import LLMReranker, OpenAICompatibleRerankerBackend
 
 
 class FakeEmbeddingBackend:
@@ -39,6 +42,130 @@ class FakeDatabase:
     async def fetch(self, sql: str, *params: object) -> list[dict[str, object]]:
         self.fetch_calls.append((sql, params))
         return self.rows
+
+
+class StaticReranker:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[str]]] = []
+        self.top_n = 20
+
+    async def rerank(
+        self,
+        query: str,
+        candidates: list[dict[str, object]],
+        top_n: int | None = None,
+    ) -> list[dict[str, object]]:
+        self.calls.append((query, [str(candidate["id"]) for candidate in candidates]))
+        return [dict(candidate) for candidate in candidates]
+
+
+class RecordingAnswerGenerator:
+    def __init__(self, answer: str | None = None) -> None:
+        self.answer = answer
+        self.calls: list[tuple[str, list[str]]] = []
+
+    async def generate(
+        self,
+        query: str,
+        segments: list[dict[str, object]],
+    ) -> str | None:
+        self.calls.append((query, [str(segment["id"]) for segment in segments]))
+        return self.answer
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            response = httpx.Response(self.status_code, request=self.request)
+            raise httpx.HTTPStatusError(
+                "request failed",
+                request=self.request,
+                response=response,
+            )
+
+
+def install_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    responses: list[object],
+    requests: list[dict[str, object]],
+) -> None:
+    class StubAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "StubAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            traceback: object,
+        ) -> bool:
+            return False
+
+        async def post(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            json: dict[str, object],
+        ) -> FakeHTTPResponse:
+            requests.append(
+                {
+                    "url": url,
+                    "headers": headers,
+                    "json": json,
+                }
+            )
+            next_response = responses.pop(0)
+            if isinstance(next_response, Exception):
+                raise next_response
+            return next_response
+
+    monkeypatch.setattr(httpx, "AsyncClient", StubAsyncClient)
+
+
+def build_knowledge_row(
+    *,
+    row_id: str,
+    score: float,
+    embedding: list[float],
+    title: str = "OpenAI Dev Day Keynote",
+    segment_title: str = "Agent workflows and reasoning models",
+    transcript_text: str = "Agents can use reasoning models to plan and execute tasks more reliably.",
+    visual_summary: str = "Presenter speaking on stage with slides about agent workflows.",
+    timestamp_start: float = 120.0,
+    timestamp_end: float = 178.5,
+) -> dict[str, object]:
+    return {
+        "id": row_id,
+        "title": title,
+        "segment_title": segment_title,
+        "description": "Discussion about agent workflows and reasoning models.",
+        "transcript_text": transcript_text,
+        "visual_summary": visual_summary,
+        "video_url": "https://example.com/keynote.mp4",
+        "thumbnail_url": "https://example.com/keynote.jpg",
+        "duration": 3600,
+        "source": "youtube",
+        "license": "standard-youtube-license",
+        "speaker": "Sam Altman",
+        "published_at": "2025-11-06T00:00:00Z",
+        "timestamp_start": timestamp_start,
+        "timestamp_end": timestamp_end,
+        "embedding": embedding,
+        "score": score,
+    }
 
 
 def test_resolve_search_service_rejects_unknown_search_type() -> None:
@@ -115,24 +242,19 @@ def test_knowledge_search_prefers_explicit_query_vector_over_embedding_backend()
     )
     database = FakeDatabase(
         [
-            {
-                "id": "segment_1",
-                "title": "Agent workflows and reasoning models",
-                "description": "Discussion about agent workflows and reasoning models.",
-                "video_url": "https://example.com/keynote.mp4",
-                "thumbnail_url": "https://example.com/keynote.jpg",
-                "duration": 3600,
-                "source": "youtube",
-                "license": "standard-youtube-license",
-                "timestamp_start": 120.0,
-                "timestamp_end": 178.5,
-                "embedding": embedded_vector,
-                "score": 0.88,
-            }
+            build_knowledge_row(
+                row_id="segment_1",
+                score=0.88,
+                embedding=embedded_vector,
+            )
         ]
     )
     embedding_backend = FakeEmbeddingBackend(embedded_vector)
-    service = KnowledgeSearchService(database, embedding_backend=embedding_backend)
+    service = KnowledgeSearchService(
+        database,
+        embedding_backend=embedding_backend,
+        reranker=StaticReranker(),
+    )
     request = SearchRequest.model_validate(
         {
             "query": "agent workflows",
@@ -147,3 +269,208 @@ def test_knowledge_search_prefers_explicit_query_vector_over_embedding_backend()
     assert results[0].id == "segment_1"
     assert embedding_backend.calls == []
     assert database.fetch_calls[0][1][0] == vector_to_literal(explicit_vector)
+
+
+def test_llm_reranker_reorders_candidates_by_llm_score(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, object]] = []
+    responses: list[object] = [
+        FakeHTTPResponse({"choices": [{"message": {"content": '{"score": 2}'}}]}),
+        FakeHTTPResponse({"choices": [{"message": {"content": '{"score": 9}'}}]}),
+        FakeHTTPResponse({"choices": [{"message": {"content": '{"score": 6}'}}]}),
+    ]
+    install_async_client(monkeypatch, responses=responses, requests=requests)
+
+    embedding = build_placeholder_vector(
+        "reranker candidate embedding",
+        DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+    )
+    candidates = [
+        build_knowledge_row(row_id="segment_1", score=0.90, embedding=embedding),
+        build_knowledge_row(row_id="segment_2", score=0.80, embedding=embedding),
+        build_knowledge_row(row_id="segment_3", score=0.70, embedding=embedding),
+    ]
+    reranker = LLMReranker(
+        backend=OpenAICompatibleRerankerBackend(api_key="test-openai-key"),
+        top_n=3,
+    )
+
+    reranked = asyncio.run(reranker.rerank("agent workflows", candidates))
+
+    assert [candidate["id"] for candidate in reranked] == [
+        "segment_2",
+        "segment_3",
+        "segment_1",
+    ]
+    assert reranked[0]["rerank_score"] == pytest.approx(0.9)
+    assert len(requests) == 3
+    assert requests[0]["url"] == "https://api.openai.com/v1/chat/completions"
+
+
+def test_llm_reranker_falls_back_to_original_order_on_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, object]] = []
+    responses: list[object] = [httpx.ConnectError("boom")]
+    install_async_client(monkeypatch, responses=responses, requests=requests)
+
+    embedding = build_placeholder_vector(
+        "reranker fallback embedding",
+        DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+    )
+    candidates = [
+        build_knowledge_row(row_id="segment_low", score=0.40, embedding=embedding),
+        build_knowledge_row(row_id="segment_high", score=0.95, embedding=embedding),
+    ]
+    reranker = LLMReranker(
+        backend=OpenAICompatibleRerankerBackend(api_key="test-openai-key"),
+        top_n=1,
+    )
+
+    reranked = asyncio.run(reranker.rerank("agent workflows", candidates))
+
+    assert [candidate["id"] for candidate in reranked] == [
+        "segment_high",
+        "segment_low",
+    ]
+    assert len(requests) == 1
+
+
+def test_answer_generator_produces_answer_with_citations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, object]] = []
+    responses: list[object] = [
+        FakeHTTPResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                "The speaker says agents can plan and execute tasks more "
+                                "reliably with reasoning models [OpenAI Dev Day Keynote, 2:00-2:58]."
+                            )
+                        }
+                    }
+                ]
+            }
+        )
+    ]
+    install_async_client(monkeypatch, responses=responses, requests=requests)
+
+    generator = AnswerGenerator(
+        backend=OpenAICompatibleAnswerBackend(api_key="test-openai-key")
+    )
+    segments = [
+        build_knowledge_row(
+            row_id="segment_1",
+            score=0.88,
+            embedding=build_placeholder_vector(
+                "answer generator embedding",
+                DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+            ),
+        )
+    ]
+
+    answer = asyncio.run(generator.generate("agent workflows", segments))
+
+    assert answer is not None
+    assert "[OpenAI Dev Day Keynote, 2:00-2:58]" in answer
+    assert len(requests) == 1
+    assert "Retrieved evidence segments" in str(requests[0]["json"])
+
+
+def test_answer_generator_returns_none_on_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, object]] = []
+    responses: list[object] = [httpx.ConnectError("boom")]
+    install_async_client(monkeypatch, responses=responses, requests=requests)
+
+    generator = AnswerGenerator(
+        backend=OpenAICompatibleAnswerBackend(api_key="test-openai-key")
+    )
+    segments = [
+        build_knowledge_row(
+            row_id="segment_1",
+            score=0.88,
+            embedding=build_placeholder_vector(
+                "answer generator error embedding",
+                DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+            ),
+        )
+    ]
+
+    answer = asyncio.run(generator.generate("agent workflows", segments))
+
+    assert answer is None
+    assert len(requests) == 1
+
+
+def test_knowledge_search_skips_answer_generation_when_include_answer_false() -> None:
+    embedding = build_placeholder_vector(
+        "knowledge search skip answer",
+        DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+    )
+    database = FakeDatabase(
+        [build_knowledge_row(row_id="segment_1", score=0.88, embedding=embedding)]
+    )
+    answer_generator = RecordingAnswerGenerator(
+        answer="Shared answer [OpenAI Dev Day Keynote, 2:00-2:58]."
+    )
+    service = KnowledgeSearchService(
+        database,
+        embedding_backend=FakeEmbeddingBackend(embedding),
+        reranker=StaticReranker(),
+        answer_generator=answer_generator,
+    )
+    request = SearchRequest.model_validate(
+        {
+            "query": "agent workflows",
+            "search_type": "knowledge",
+            "max_results": 1,
+            "include_answer": False,
+        }
+    )
+
+    results = asyncio.run(service.search(request))
+
+    assert len(results) == 1
+    assert results[0].answer is None
+    assert answer_generator.calls == []
+
+
+def test_knowledge_search_includes_answer_when_include_answer_true() -> None:
+    embedding = build_placeholder_vector(
+        "knowledge search include answer",
+        DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+    )
+    database = FakeDatabase(
+        [build_knowledge_row(row_id="segment_1", score=0.88, embedding=embedding)]
+    )
+    answer_text = (
+        "Reasoning models help agents plan tasks more reliably "
+        "[OpenAI Dev Day Keynote, 2:00-2:58]."
+    )
+    answer_generator = RecordingAnswerGenerator(answer=answer_text)
+    service = KnowledgeSearchService(
+        database,
+        embedding_backend=FakeEmbeddingBackend(embedding),
+        reranker=StaticReranker(),
+        answer_generator=answer_generator,
+    )
+    request = SearchRequest.model_validate(
+        {
+            "query": "agent workflows",
+            "search_type": "knowledge",
+            "max_results": 1,
+            "include_answer": True,
+        }
+    )
+
+    results = asyncio.run(service.search(request))
+
+    assert len(results) == 1
+    assert results[0].answer == answer_text
+    assert answer_generator.calls == [("agent workflows", ["segment_1"])]


### PR DESCRIPTION
## Summary
- add LLM-based knowledge reranking with graceful fallback to vector ordering
- add answer generation with timestamp citations for include_answer=true requests
- wire KnowledgeSearchService to rerank, diversify, and generate answers with timing logs

## Affected directories
- backend/app/search
- backend/tests

## Config / env
- no new env vars
- reuses existing OPENAI_API_KEY
- consumes existing knowledge.rerank_top_n and knowledge.rerank_prompt_template

## Testing
- python3 -m pytest backend/tests/test_search_services.py backend/tests/test_search_api.py -v

## API notes
Request shape is unchanged. Knowledge results now use reranked relevance scores and may include synthesized answer text when include_answer=true.