### PR TITLE
Scale B-roll ingestion pipeline for batch seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ artifacts/
 *.log
 ARCHITECTURE.md
 PIPELINE_PATTERN.md
+scripts/.seed_broll_state.json

--- a/scripts/broll_queries.txt
+++ b/scripts/broll_queries.txt
@@ -1,0 +1,220 @@
+aerial mountain sunrise
+ocean waves crashing rocks
+forest river drone flyover
+desert dunes golden hour
+waterfall mist slow motion
+alpine lake reflection morning
+snowy pine forest aerial
+volcanic landscape drone shot
+tropical jungle canopy
+canyon river winding aerial
+wildflower meadow breeze
+glacier lagoon blue ice
+northern lights over mountains
+coastal cliffs dramatic surf
+rainforest waterfall wide shot
+sunlight through redwood trees
+rolling hills countryside
+foggy valley dawn
+rocky shoreline tide pools
+lush green valley aerial
+desert road through landscape
+moonlit lake night sky
+tokyo neon streets night
+new york skyline timelapse
+city traffic aerial sunset
+subway station commuters rush
+downtown crosswalk pedestrians
+urban rooftop skyline dusk
+rainy city street reflections
+modern skyscraper glass facade
+night market crowded alley
+elevated train through city
+bike messenger downtown street
+street cafe european city
+bridge traffic long exposure
+city park joggers morning
+empty street before sunrise
+street art mural closeup
+old town narrow streets
+smart city aerial twilight
+construction cranes skyline
+financial district office towers
+busy intersection overhead view
+city skyline from ferry
+coffee shop working laptop
+friends laughing dinner
+family cooking together kitchen
+remote worker home office
+couple walking beach sunset
+children playing park afternoon
+young woman reading window light
+man tying shoelaces closeup
+multiracial team casual conversation
+barista making pour over coffee
+artist painting studio canvas
+musician practicing guitar home
+student studying library table
+friends road trip in car
+parent holding baby slow motion
+chef plating food restaurant
+woman journaling morning routine
+people dancing rooftop sunset
+group hiking trail together
+hands typing laptop closeup
+smiling portrait natural light
+friends picnic in park
+data center server room
+robot arm manufacturing
+developer coding multiple monitors
+circuit board macro shot
+drone takeoff closeup
+electric vehicle charging station
+warehouse automation robots
+cybersecurity operations center
+satellite dish sunset
+3d printer timelapse
+smartphone app scrolling hands
+augmented reality headset demo
+solar panels aerial inspection
+wind turbine maintenance
+laptop motherboard repair
+cloud computing abstract screens
+machine learning dashboard
+biotech lab microscope
+semiconductor clean room
+camera gimbal setup
+network cables server rack
+robot dog walking lab
+corporate meeting room
+startup team brainstorming
+executive handshake office
+presentation conference room
+coworking space collaboration
+businesswoman walking lobby
+boardroom discussion wide shot
+phone call office window
+analyst reviewing charts
+team whiteboard planning sprint
+entrepreneur recording pitch
+small business owner storefront
+law office paperwork signing
+customer service headset desk
+office coffee break candid
+creative agency workshop
+warehouse logistics planning
+finance team reviewing data
+consultant meeting client
+modern office empty desks
+sales team celebrating win
+reception desk corporate lobby
+sushi chef preparation
+fresh vegetables market
+artisan bread bakery
+street food vendor grill
+coffee beans roasting
+pasta dough making closeup
+farmers market fruit stand
+cocktail pouring slow motion
+breakfast table overhead
+salad ingredients preparation
+chef knife chopping herbs
+pizza oven fire flames
+dessert plating fine dining
+tea pouring ceramic cup
+barbecue smoke outdoor cooking
+smoothie blender kitchen
+fresh seafood on ice
+ramen bowl steam closeup
+wine pouring restaurant
+homemade cookies baking
+olive oil drizzle salad
+busy restaurant kitchen line
+tropical beach sunset
+european cobblestone streets
+airport departure board travelers
+train through countryside
+passport boarding pass closeup
+camper van mountain road
+hotel lobby check in
+luggage rolling airport terminal
+ancient temple sunrise
+island boat aerial view
+desert safari jeep
+scenic coastal highway drive
+mountain village winter
+backpacker viewpoint panorama
+city tram historic district
+resort pool palm trees
+ferry approaching harbor
+road sign scenic route
+campfire under stars
+hammock in tropical resort
+market street travel destination
+sunrise over hot air balloons
+runner morning jogger
+yoga studio meditation
+basketball court practice
+surfer riding wave
+cyclist mountain road
+gym weightlifting closeup
+soccer training field
+tennis serve slow motion
+hiker summit celebration
+swimmer pool lane underwater
+boxing workout heavy bag
+skateboard trick urban park
+rock climbing indoor wall
+marathon runners city street
+pilates reformer class
+skiing powder turn
+snowboard jump mountain
+rowing team water sunrise
+fitness class group workout
+stretching before exercise
+trail runner forest path
+meditation breathing closeup
+paint splash slow motion
+bokeh lights colorful
+ink in water macro
+prism light refraction
+smoke swirling black background
+liquid metal texture
+neon gradient motion graphics
+glass reflections abstract
+paper cut shadows minimal
+geometric shapes rotating
+laser lights haze
+color powder explosion
+water droplets macro surface
+soft fabric waving
+chromatic light leaks
+mirror fragments abstract
+defocused traffic lights
+digital glitch background
+iridescent foil texture
+shadow patterns wall
+spark particles dark studio
+abstract architecture lines
+thunderstorm lightning
+autumn leaves falling
+snowflakes window closeup
+heavy rain city umbrella
+fog rolling over hills
+sun rays after storm
+hail hitting pavement
+wind blowing wheat field
+winter forest snowfall
+spring blossoms breeze
+summer heat shimmer road
+storm clouds timelapse
+frost on grass morning
+icy branches closeup
+monsoon rain street
+golden autumn forest path
+misty lake sunrise
+cloud shadows over mountains
+rain drops on window
+blizzard conditions road
+sunset after rain puddles
+first snow in city park

--- a/scripts/seed_broll.py
+++ b/scripts/seed_broll.py
@@ -1,50 +1,315 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import asyncio
+import json
+import os
 import sys
+import time
+from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Any
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_QUERY_FILE = ROOT_DIR / "scripts" / "broll_queries.txt"
+DEFAULT_STATE_FILE = ROOT_DIR / "scripts" / ".seed_broll_state.json"
 
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from workers.broll import BrollIndexingPipeline, InMemoryBrollAssetRepository
+from workers.broll import BrollAssetRepository, BrollIndexingPipeline  # noqa: E402
 
 
-async def _run_pipeline(query: str) -> int:
-    repository = InMemoryBrollAssetRepository()
-    pipeline = BrollIndexingPipeline(repository=repository)
-    context = await pipeline.run(query)
+PipelineFactory = Callable[[BrollAssetRepository], BrollIndexingPipeline]
 
-    if context.failed_step is not None:
-        print(f"Pipeline failed at {context.failed_step}: {context.error}")
-        return 1
 
-    _print_error_bucket("Discovery warning", context.data.get("discovery_warnings", {}))
-    _print_error_bucket("Metadata error", context.data.get("metadata_errors", {}))
-    _print_error_bucket(
-        "Preview download error",
-        context.data.get("frame_download_errors", {}),
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed Cerul B-roll assets.")
+    parser.add_argument("--query", help='Single query mode, e.g. "aerial mountain sunrise"')
+    parser.add_argument(
+        "--file",
+        default=str(DEFAULT_QUERY_FILE),
+        help="Batch mode query file path",
     )
-    _print_error_bucket("Embedding error", context.data.get("embedding_errors", {}))
+    parser.add_argument(
+        "--source",
+        choices=("pexels", "pixabay", "all"),
+        default="all",
+        help="Content source selection",
+    )
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=50,
+        help="Results fetched per provider API call",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=10,
+        help="Maximum pagination depth per query",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip queries already marked as completed in the state file",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be processed without making API calls",
+    )
+    parser.add_argument(
+        "--db-url",
+        help="Database URL override. Defaults to DATABASE_URL.",
+    )
+    return parser
 
-    print(f"Discovered: {context.data.get('discovered_assets_count', 0)}")
-    print(f"New: {context.data.get('new_assets_count', 0)}")
-    print(f"Indexed: {context.data.get('indexed_assets_count', 0)}")
+
+async def run_seed(
+    args: argparse.Namespace,
+    *,
+    state_path: Path = DEFAULT_STATE_FILE,
+    pipeline_factory: PipelineFactory | None = None,
+) -> int:
+    queries = load_queries(
+        query=args.query,
+        file_path=Path(args.file) if args.file else DEFAULT_QUERY_FILE,
+    )
+    state = load_state(state_path)
+    sources = resolve_sources(args.source)
+
+    if args.dry_run:
+        _print_dry_run_plan(
+            queries=queries,
+            state=state,
+            sources=sources,
+            per_page=args.per_page,
+            max_pages=args.max_pages,
+            resume=args.resume,
+        )
+        return 0
+
+    db_url = resolve_db_url(args.db_url)
+    repository = BrollAssetRepository(db_url)
+    await repository.connect()
+    pipeline = (
+        pipeline_factory(repository)
+        if pipeline_factory is not None
+        else BrollIndexingPipeline(repository=repository, db_url=db_url)
+    )
+
+    total_queries = len(queries)
+    started_at = time.monotonic()
+    executed_queries = 0
+
+    try:
+        for index, query in enumerate(queries, start=1):
+            query_state = state.get(query, {})
+            if args.resume and query_state.get("status") == "completed":
+                print(f"Query {index}/{total_queries} '{query}': skipped (completed)")
+                continue
+
+            query_started_at = time.monotonic()
+            try:
+                context = await pipeline.run(
+                    query,
+                    conf={
+                        "sources": sources,
+                        "per_page": args.per_page,
+                        "max_pages": args.max_pages,
+                    },
+                )
+            except Exception as exc:
+                state[query] = {
+                    "status": "failed",
+                    "assets_found": 0,
+                    "assets_indexed": 0,
+                    "last_page": 0,
+                    "error": str(exc),
+                }
+                save_state(state_path, state)
+                print(f"Query {index}/{total_queries} '{query}': failed ({exc})")
+                continue
+
+            query_state = build_query_state(context=context)
+            state[query] = query_state
+            save_state(state_path, state)
+
+            executed_queries += 1
+            eta_seconds = estimate_remaining_seconds(
+                started_at=started_at,
+                processed_queries=executed_queries,
+                remaining_queries=total_queries - index,
+            )
+            elapsed_seconds = time.monotonic() - query_started_at
+
+            if context.failed_step is not None:
+                error_message = context.error or f"failed at {context.failed_step}"
+                print(
+                    f"Query {index}/{total_queries} '{query}': failed "
+                    f"({error_message})"
+                )
+                continue
+
+            print(
+                f"Query {index}/{total_queries} '{query}': "
+                f"{query_state['assets_found']} discovered, "
+                f"{query_state['new_assets']} new, "
+                f"{query_state['assets_indexed']} indexed "
+                f"[{format_duration(elapsed_seconds)} elapsed, "
+                f"ETA {format_duration(eta_seconds)}]"
+            )
+    finally:
+        await repository.close()
+
+    completed_queries = [
+        query for query in queries if state.get(query, {}).get("status") == "completed"
+    ]
+    total_indexed = sum(
+        int(state[query].get("assets_indexed", 0)) for query in completed_queries
+    )
+    print(
+        f"Total: {total_indexed:,} assets indexed across "
+        f"{len(completed_queries)} queries"
+    )
     return 0
 
 
-def _print_error_bucket(label: str, errors: dict[str, str]) -> None:
-    for error_key, message in errors.items():
-        print(f"{label} [{error_key}]: {message}")
+def load_queries(*, query: str | None, file_path: Path) -> list[str]:
+    if query:
+        return [normalize_query(query)]
+
+    if not file_path.exists():
+        raise FileNotFoundError(f"Query file does not exist: {file_path}")
+
+    ordered_queries: list[str] = []
+    seen_queries: set[str] = set()
+    for raw_line in file_path.read_text(encoding="utf-8").splitlines():
+        normalized_query = normalize_query(raw_line)
+        if not normalized_query or normalized_query.startswith("#"):
+            continue
+        if normalized_query in seen_queries:
+            continue
+        seen_queries.add(normalized_query)
+        ordered_queries.append(normalized_query)
+
+    if not ordered_queries:
+        raise ValueError("No valid B-roll queries were found.")
+    return ordered_queries
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Seed Cerul B-roll assets.")
-    parser.add_argument("query", help='Search query, e.g. "cinematic drone shot"')
-    args = parser.parse_args()
-    return asyncio.run(_run_pipeline(args.query))
+def normalize_query(value: str) -> str:
+    return value.strip()
+
+
+def load_state(state_path: Path) -> dict[str, dict[str, Any]]:
+    if not state_path.exists():
+        return {}
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Seed state file must contain a JSON object.")
+    return {
+        str(query): dict(value)
+        for query, value in payload.items()
+        if isinstance(value, dict)
+    }
+
+
+def save_state(state_path: Path, state: dict[str, dict[str, Any]]) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(state, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def resolve_sources(source_name: str) -> list[str]:
+    if source_name == "all":
+        return ["pexels", "pixabay"]
+    return [source_name]
+
+
+def resolve_db_url(explicit_db_url: str | None) -> str:
+    db_url = (explicit_db_url or os.getenv("DATABASE_URL") or "").strip()
+    if not db_url:
+        raise RuntimeError("DATABASE_URL is required unless --dry-run is set.")
+    return db_url
+
+
+def build_query_state(*, context: Any) -> dict[str, Any]:
+    assets_found = int(context.data.get("discovered_assets_count", 0))
+    assets_indexed = int(context.data.get("indexed_assets_count", 0))
+    return {
+        "status": "failed" if context.failed_step is not None else "completed",
+        "assets_found": assets_found,
+        "new_assets": int(context.data.get("new_assets_count", 0)),
+        "assets_indexed": assets_indexed,
+        "last_page": int(context.data.get("last_discovery_page", 0)),
+        "error": context.error,
+    }
+
+
+def estimate_remaining_seconds(
+    *,
+    started_at: float,
+    processed_queries: int,
+    remaining_queries: int,
+) -> float:
+    if processed_queries <= 0 or remaining_queries <= 0:
+        return 0.0
+
+    average_seconds = (time.monotonic() - started_at) / processed_queries
+    return average_seconds * remaining_queries
+
+
+def format_duration(seconds: float) -> str:
+    total_seconds = max(int(seconds), 0)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours:d}h{minutes:02d}m{secs:02d}s"
+    if minutes:
+        return f"{minutes:d}m{secs:02d}s"
+    return f"{secs:d}s"
+
+
+def _print_dry_run_plan(
+    *,
+    queries: Sequence[str],
+    state: dict[str, dict[str, Any]],
+    sources: Sequence[str],
+    per_page: int,
+    max_pages: int,
+    resume: bool,
+) -> None:
+    total_queries = len(queries)
+    max_assets_per_query = per_page * max_pages * len(sources)
+    for index, query in enumerate(queries, start=1):
+        if resume and state.get(query, {}).get("status") == "completed":
+            print(f"Query {index}/{total_queries} '{query}': skipped (completed)")
+            continue
+        print(
+            f"Query {index}/{total_queries} '{query}': dry-run, up to "
+            f"{max_assets_per_query} assets from {', '.join(sources)}"
+        )
+
+    print(
+        f"Dry run: {total_queries} queries, up to "
+        f"{max_assets_per_query * total_queries:,} source assets total"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(run_seed(args))
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/workers/broll/__init__.py
+++ b/workers/broll/__init__.py
@@ -1,4 +1,15 @@
 from .pipeline import BrollIndexingPipeline
-from .repository import BrollAssetRepository, InMemoryBrollAssetRepository
+from .repository import (
+    BrollAssetRepository,
+    BrollAssetRepositoryProtocol,
+    InMemoryBrollAssetRepository,
+    resolve_default_broll_repository,
+)
 
-__all__ = ["BrollAssetRepository", "BrollIndexingPipeline", "InMemoryBrollAssetRepository"]
+__all__ = [
+    "BrollAssetRepository",
+    "BrollAssetRepositoryProtocol",
+    "BrollIndexingPipeline",
+    "InMemoryBrollAssetRepository",
+    "resolve_default_broll_repository",
+]

--- a/workers/broll/pipeline.py
+++ b/workers/broll/pipeline.py
@@ -5,7 +5,10 @@ from backend.app.embedding import EmbeddingBackend, GeminiEmbeddingBackend
 from workers.common.pipeline import PipelineContext, PipelineExecutor
 from workers.common.sources import PexelsClient, PixabayClient
 
-from .repository import BrollAssetRepository, InMemoryBrollAssetRepository
+from .repository import (
+    BrollAssetRepositoryProtocol,
+    resolve_default_broll_repository,
+)
 from .steps import (
     DiscoverAssetStep,
     DownloadPreviewFrameStep,
@@ -19,13 +22,14 @@ from .steps import (
 class BrollIndexingPipeline:
     def __init__(
         self,
-        repository: BrollAssetRepository | None = None,
+        repository: BrollAssetRepositoryProtocol | None = None,
         embedding_backend: EmbeddingBackend | None = None,
         pexels_client: PexelsClient | None = None,
         pixabay_client: PixabayClient | None = None,
         temp_dir_root: str | None = None,
+        db_url: str | None = None,
     ) -> None:
-        self._repository = repository or InMemoryBrollAssetRepository()
+        self._repository = repository or resolve_default_broll_repository(db_url)
         self._embedding_backend = embedding_backend or GeminiEmbeddingBackend()
         self._pexels_client = pexels_client or PexelsClient()
         self._pixabay_client = pixabay_client or PixabayClient()

--- a/workers/broll/repository.py
+++ b/workers/broll/repository.py
@@ -1,18 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol
+from uuid import uuid4
 
 
-class BrollAssetRepository(Protocol):
+class BrollAssetRepositoryProtocol(Protocol):
+    async def connect(self) -> None:
+        ...
+
+    async def close(self) -> None:
+        ...
+
     async def asset_exists(self, source: str, source_asset_id: str) -> bool:
         ...
 
-    async def upsert_broll_asset(
+    async def bulk_check_existing(
+        self,
+        assets: Sequence[Mapping[str, Any]],
+    ) -> set[str]:
+        ...
+
+    async def store_asset(
         self,
         asset: Mapping[str, Any],
         embedding: Sequence[float],
-        frame_path: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> None:
+        ...
+
+    async def store_assets_batch(
+        self,
+        assets: Sequence[Mapping[str, Any]],
+        embeddings: Sequence[Sequence[float]],
+    ) -> int:
+        ...
+
+    async def count_assets(self) -> int:
         ...
 
     async def mark_job_completed(
@@ -23,15 +50,287 @@ class BrollAssetRepository(Protocol):
         ...
 
 
+class BrollAssetRepository:
+    def __init__(self, db_url: str) -> None:
+        self._db_url = db_url
+        self._pool: Any | None = None
+        self._pool_lock = asyncio.Lock()
+
+    async def connect(self) -> None:
+        if self._pool is not None:
+            return
+
+        async with self._pool_lock:
+            if self._pool is not None:
+                return
+
+            asyncpg = _import_asyncpg()
+            self._pool = await asyncpg.create_pool(
+                dsn=self._db_url,
+                min_size=1,
+                max_size=10,
+                command_timeout=60,
+            )
+
+    async def close(self) -> None:
+        if self._pool is None:
+            return
+
+        await self._pool.close()
+        self._pool = None
+
+    async def asset_exists(self, source: str, source_asset_id: str) -> bool:
+        pool = await self._get_pool()
+        async with pool.acquire() as connection:
+            row = await connection.fetchrow(
+                """
+                SELECT 1
+                FROM broll_assets
+                WHERE source = $1
+                  AND source_asset_id = $2
+                """,
+                source,
+                source_asset_id,
+            )
+        return row is not None
+
+    async def bulk_check_existing(
+        self,
+        assets: Sequence[Mapping[str, Any]],
+    ) -> set[str]:
+        if not assets:
+            return set()
+
+        lookup: dict[tuple[str, str], str] = {}
+        sources: list[str] = []
+        source_asset_ids: list[str] = []
+        for asset in assets:
+            source = str(asset["source"])
+            source_asset_id = str(asset["source_asset_id"])
+            lookup[(source, source_asset_id)] = str(asset.get("id") or "")
+            sources.append(source)
+            source_asset_ids.append(source_asset_id)
+
+        pool = await self._get_pool()
+        async with pool.acquire() as connection:
+            rows = await connection.fetch(
+                """
+                SELECT source, source_asset_id
+                FROM broll_assets
+                WHERE (source, source_asset_id) IN (
+                    SELECT *
+                    FROM UNNEST($1::text[], $2::text[])
+                )
+                """,
+                sources,
+                source_asset_ids,
+            )
+
+        existing_ids: set[str] = set()
+        for row in rows:
+            asset_id = lookup.get((str(row["source"]), str(row["source_asset_id"])))
+            if asset_id:
+                existing_ids.add(asset_id)
+
+        return existing_ids
+
+    async def store_asset(
+        self,
+        asset: Mapping[str, Any],
+        embedding: Sequence[float],
+    ) -> None:
+        pool = await self._get_pool()
+        async with pool.acquire() as connection:
+            await connection.execute(
+                _UPSERT_BROLL_ASSET_QUERY,
+                *self._build_asset_record(asset, embedding),
+            )
+
+    async def store_assets_batch(
+        self,
+        assets: Sequence[Mapping[str, Any]],
+        embeddings: Sequence[Sequence[float]],
+    ) -> int:
+        if len(assets) != len(embeddings):
+            raise ValueError("assets and embeddings must have the same length.")
+        if not assets:
+            return 0
+
+        records = [
+            self._build_asset_record(asset, embedding)
+            for asset, embedding in zip(assets, embeddings, strict=True)
+        ]
+
+        pool = await self._get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.executemany(_UPSERT_BROLL_ASSET_QUERY, records)
+
+        return len(records)
+
+    async def count_assets(self) -> int:
+        pool = await self._get_pool()
+        async with pool.acquire() as connection:
+            count = await connection.fetchval("SELECT COUNT(*) FROM broll_assets")
+        return int(count or 0)
+
+    async def mark_job_completed(
+        self,
+        job_id: str | None,
+        artifacts: Mapping[str, Any],
+    ) -> None:
+        if job_id is None:
+            return
+
+        pool = await self._get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    """
+                    UPDATE processing_jobs
+                    SET
+                        status = 'completed',
+                        error_message = NULL,
+                        completed_at = NOW(),
+                        updated_at = NOW()
+                    WHERE id = $1::uuid
+                    """,
+                    job_id,
+                )
+                await connection.execute(
+                    """
+                    INSERT INTO processing_job_steps (
+                        job_id,
+                        step_name,
+                        status,
+                        artifacts,
+                        started_at,
+                        completed_at,
+                        updated_at
+                    )
+                    VALUES (
+                        $1::uuid,
+                        $2,
+                        'completed',
+                        $3::jsonb,
+                        NOW(),
+                        NOW(),
+                        NOW()
+                    )
+                    ON CONFLICT (job_id, step_name) DO UPDATE
+                    SET
+                        status = 'completed',
+                        artifacts = EXCLUDED.artifacts,
+                        completed_at = NOW(),
+                        updated_at = NOW()
+                    """,
+                    job_id,
+                    "broll.pipeline.completed",
+                    json.dumps(dict(artifacts), default=str),
+                )
+
+    async def upsert_broll_asset(
+        self,
+        asset: Mapping[str, Any],
+        embedding: Sequence[float],
+        frame_path: str | None = None,
+    ) -> dict[str, Any]:
+        payload = self._build_persisted_asset_payload(
+            asset=asset,
+            embedding=embedding,
+            frame_path=frame_path,
+        )
+        await self.store_asset(asset, embedding)
+        return payload
+
+    async def _get_pool(self) -> Any:
+        await self.connect()
+        if self._pool is None:
+            raise RuntimeError("B-roll database pool is not initialized.")
+        return self._pool
+
+    def _build_asset_record(
+        self,
+        asset: Mapping[str, Any],
+        embedding: Sequence[float],
+    ) -> tuple[Any, ...]:
+        return (
+            asset["source"],
+            asset["source_asset_id"],
+            asset.get("source_url"),
+            asset["video_url"],
+            asset.get("thumbnail_url"),
+            asset.get("duration_seconds", asset.get("duration")),
+            asset["title"],
+            asset.get("description", ""),
+            [str(tag) for tag in asset.get("tags", [])],
+            asset.get("license"),
+            asset.get("creator"),
+            json.dumps(asset.get("metadata", {}), default=str),
+            _vector_to_literal(embedding),
+        )
+
+    def _build_persisted_asset_payload(
+        self,
+        *,
+        asset: Mapping[str, Any],
+        embedding: Sequence[float],
+        frame_path: str | None,
+    ) -> dict[str, Any]:
+        payload = dict(asset)
+        payload["embedding"] = list(embedding)
+        payload["frame_path"] = frame_path
+        return payload
+
+
 @dataclass(slots=True)
 class InMemoryBrollAssetRepository:
-    # STUB: replace with a database-backed repository after the shared DB layer lands.
     existing_assets: set[tuple[str, str]] = field(default_factory=set)
     stored_assets: list[dict[str, Any]] = field(default_factory=list)
     completed_jobs: dict[str, dict[str, Any]] = field(default_factory=dict)
 
+    async def connect(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
     async def asset_exists(self, source: str, source_asset_id: str) -> bool:
         return (source, source_asset_id) in self.existing_assets
+
+    async def bulk_check_existing(
+        self,
+        assets: Sequence[Mapping[str, Any]],
+    ) -> set[str]:
+        existing_ids: set[str] = set()
+        for asset in assets:
+            asset_key = (str(asset["source"]), str(asset["source_asset_id"]))
+            if asset_key in self.existing_assets and asset.get("id"):
+                existing_ids.add(str(asset["id"]))
+        return existing_ids
+
+    async def store_asset(
+        self,
+        asset: Mapping[str, Any],
+        embedding: Sequence[float],
+    ) -> None:
+        await self.upsert_broll_asset(asset, embedding)
+
+    async def store_assets_batch(
+        self,
+        assets: Sequence[Mapping[str, Any]],
+        embeddings: Sequence[Sequence[float]],
+    ) -> int:
+        if len(assets) != len(embeddings):
+            raise ValueError("assets and embeddings must have the same length.")
+
+        for asset, embedding in zip(assets, embeddings, strict=True):
+            await self.upsert_broll_asset(asset, embedding)
+
+        return len(assets)
+
+    async def count_assets(self) -> int:
+        return len(self.stored_assets)
 
     async def upsert_broll_asset(
         self,
@@ -40,10 +339,11 @@ class InMemoryBrollAssetRepository:
         frame_path: str | None = None,
     ) -> dict[str, Any]:
         payload = dict(asset)
+        payload["id"] = str(payload.get("id") or uuid4())
         payload["embedding"] = list(embedding)
         payload["frame_path"] = frame_path
 
-        key = (payload["source"], payload["source_asset_id"])
+        key = (str(payload["source"]), str(payload["source_asset_id"]))
         self.existing_assets.add(key)
 
         for index, existing_asset in enumerate(self.stored_assets):
@@ -52,10 +352,10 @@ class InMemoryBrollAssetRepository:
                 existing_asset["source_asset_id"],
             ) == key:
                 self.stored_assets[index] = payload
-                return payload
+                return dict(payload)
 
         self.stored_assets.append(payload)
-        return payload
+        return dict(payload)
 
     async def mark_job_completed(
         self,
@@ -66,3 +366,73 @@ class InMemoryBrollAssetRepository:
             return
 
         self.completed_jobs[job_id] = dict(artifacts)
+
+
+def resolve_default_broll_repository(
+    db_url: str | None = None,
+) -> BrollAssetRepositoryProtocol:
+    database_url = (db_url or os.getenv("DATABASE_URL") or "").strip()
+    if database_url:
+        return BrollAssetRepository(database_url)
+    return InMemoryBrollAssetRepository()
+
+
+def _import_asyncpg() -> Any:
+    try:
+        import asyncpg
+    except ImportError as exc:
+        raise RuntimeError("BrollAssetRepository requires asyncpg to be installed.") from exc
+
+    return asyncpg
+
+
+def _vector_to_literal(values: Sequence[float]) -> str:
+    return "[" + ",".join(f"{float(value):.12g}" for value in values) + "]"
+
+
+_UPSERT_BROLL_ASSET_QUERY = """
+INSERT INTO broll_assets (
+    source,
+    source_asset_id,
+    source_url,
+    video_url,
+    thumbnail_url,
+    duration_seconds,
+    title,
+    description,
+    tags,
+    license,
+    creator,
+    metadata,
+    embedding
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9::text[],
+    $10,
+    $11,
+    $12::jsonb,
+    $13::vector
+)
+ON CONFLICT (source, source_asset_id) DO UPDATE
+SET
+    source_url = EXCLUDED.source_url,
+    video_url = EXCLUDED.video_url,
+    thumbnail_url = EXCLUDED.thumbnail_url,
+    duration_seconds = EXCLUDED.duration_seconds,
+    title = EXCLUDED.title,
+    description = EXCLUDED.description,
+    tags = EXCLUDED.tags,
+    license = EXCLUDED.license,
+    creator = EXCLUDED.creator,
+    metadata = EXCLUDED.metadata,
+    embedding = EXCLUDED.embedding,
+    updated_at = NOW()
+"""

--- a/workers/broll/steps/discover_asset.py
+++ b/workers/broll/steps/discover_asset.py
@@ -36,6 +36,7 @@ class DiscoverAssetStep(PipelineStep):
             raise ValueError("B-roll discovery requires query or category input.")
 
         per_page = int(context.conf.get("per_page", 50))
+        max_pages = max(int(context.conf.get("max_pages", 1)), 1)
         requested_sources = self._normalize_sources(
             context.conf.get("sources", ["pexels", "pixabay"])
         )
@@ -45,44 +46,72 @@ class DiscoverAssetStep(PipelineStep):
             "pixabay": self._pixabay_client or context.conf.get("pixabay_client"),
         }
 
-        coroutines: list[Any] = []
-        source_names: list[str] = []
-        for source_name in requested_sources:
-            client = clients.get(source_name)
-            if client is None:
-                continue
-            source_names.append(source_name)
-            coroutines.append(
-                client.search_videos(
-                    **self._build_search_kwargs(
-                        source_name=source_name,
-                        query=query,
-                        per_page=per_page,
-                        conf=context.conf,
-                    )
-                )
-            )
-
-        if not coroutines:
+        active_sources = [
+            source_name
+            for source_name in requested_sources
+            if clients.get(source_name) is not None
+        ]
+        if not active_sources:
             raise RuntimeError("No content source clients are configured for discovery.")
 
         discovered_assets: list[dict[str, Any]] = []
         warnings: dict[str, str] = {}
-        results = await asyncio.gather(*coroutines, return_exceptions=True)
+        pages_by_source: dict[str, int] = {}
+        attempted_sources: set[str] = set()
 
-        for source_name, result in zip(source_names, results, strict=True):
-            if isinstance(result, Exception):
-                warnings[source_name] = str(result)
-                continue
+        for page_number in range(1, max_pages + 1):
+            coroutines: list[Any] = []
+            source_names: list[str] = []
 
-            discovered_assets.extend(
-                {"source": source_name, "payload": payload} for payload in result
-            )
+            for source_name in active_sources:
+                client = clients.get(source_name)
+                if client is None:
+                    continue
 
-        if not discovered_assets and len(warnings) == len(source_names):
+                source_names.append(source_name)
+                attempted_sources.add(source_name)
+                coroutines.append(
+                    client.search_videos(
+                        **self._build_search_kwargs(
+                            source_name=source_name,
+                            query=query,
+                            per_page=per_page,
+                            page_number=page_number,
+                            conf=context.conf,
+                        )
+                    )
+                )
+
+            if not coroutines:
+                break
+
+            results = await asyncio.gather(*coroutines, return_exceptions=True)
+            next_active_sources: list[str] = []
+            for source_name, result in zip(source_names, results, strict=True):
+                if isinstance(result, Exception):
+                    warnings[f"{source_name}:page:{page_number}"] = str(result)
+                    continue
+
+                payloads = [
+                    payload for payload in result if isinstance(payload, Mapping)
+                ]
+                if payloads:
+                    pages_by_source[source_name] = page_number
+                    discovered_assets.extend(
+                        {"source": source_name, "payload": payload}
+                        for payload in payloads
+                    )
+
+                if len(payloads) >= per_page and page_number < max_pages:
+                    next_active_sources.append(source_name)
+
+            active_sources = next_active_sources
+            if not active_sources:
+                break
+
+        if not discovered_assets and attempted_sources and len(warnings) >= len(attempted_sources):
             details = "; ".join(
-                f"{source_name}: {message}"
-                for source_name, message in warnings.items()
+                f"{warning_key}: {message}" for warning_key, message in warnings.items()
             )
             raise RuntimeError(
                 f"Unable to discover assets from the configured providers. {details}"
@@ -90,6 +119,8 @@ class DiscoverAssetStep(PipelineStep):
 
         context.data["raw_assets"] = discovered_assets
         context.data["discovered_assets_count"] = len(discovered_assets)
+        context.data["discovered_pages_by_source"] = pages_by_source
+        context.data["last_discovery_page"] = max(pages_by_source.values(), default=0)
         if warnings:
             context.data["discovery_warnings"] = warnings
 
@@ -106,6 +137,7 @@ class DiscoverAssetStep(PipelineStep):
         source_name: str,
         query: str,
         per_page: int,
+        page_number: int,
         conf: Mapping[str, Any],
     ) -> dict[str, Any]:
         search_kwargs: dict[str, Any] = {
@@ -113,10 +145,15 @@ class DiscoverAssetStep(PipelineStep):
             "per_page": per_page,
         }
 
+        if source_name == "pexels":
+            if page_number > 1:
+                search_kwargs["page"] = page_number
+            return search_kwargs
+
         if source_name != "pixabay":
             return search_kwargs
 
-        pixabay_options: dict[str, Any] = {}
+        pixabay_options: dict[str, Any] = {"page": page_number}
         raw_pixabay_options = conf.get("pixabay_search_options", {})
         if isinstance(raw_pixabay_options, Mapping):
             pixabay_options.update(

--- a/workers/broll/steps/fetch_asset_metadata.py
+++ b/workers/broll/steps/fetch_asset_metadata.py
@@ -1,13 +1,13 @@
 from typing import Any
 
-from workers.broll.repository import BrollAssetRepository
+from workers.broll.repository import BrollAssetRepositoryProtocol
 from workers.common.pipeline import PipelineContext, PipelineStep
 
 
 class FetchAssetMetadataStep(PipelineStep):
     step_name = "FetchAssetMetadataStep"
 
-    def __init__(self, repository: BrollAssetRepository | None = None) -> None:
+    def __init__(self, repository: BrollAssetRepositoryProtocol | None = None) -> None:
         self._repository = repository
 
     async def _process(self, context: PipelineContext) -> None:
@@ -15,9 +15,8 @@ class FetchAssetMetadataStep(PipelineStep):
         if repository is None:
             raise RuntimeError("A B-roll asset repository is required.")
 
-        assets: list[dict[str, Any]] = []
+        normalized_assets: list[dict[str, Any]] = []
         metadata_errors: dict[str, str] = {}
-        skipped_existing_count = 0
         duplicate_asset_count = 0
         seen_asset_keys: set[tuple[str, str]] = set()
 
@@ -28,6 +27,8 @@ class FetchAssetMetadataStep(PipelineStep):
                 if not isinstance(payload, dict):
                     raise TypeError("Asset payload must be a dictionary.")
                 asset = self._normalize_asset(source, payload)
+                if not asset.get("video_url"):
+                    raise ValueError("Asset payload is missing a usable video_url.")
             except (KeyError, TypeError, ValueError) as exc:
                 metadata_errors[self._asset_error_key(raw_asset, index)] = str(exc)
                 continue
@@ -38,12 +39,13 @@ class FetchAssetMetadataStep(PipelineStep):
                 continue
 
             seen_asset_keys.add(asset_key)
+            normalized_assets.append(asset)
 
-            if await repository.asset_exists(asset["source"], asset["source_asset_id"]):
-                skipped_existing_count += 1
-                continue
-
-            assets.append(asset)
+        existing_asset_ids = await repository.bulk_check_existing(normalized_assets)
+        assets = [
+            asset for asset in normalized_assets if asset["id"] not in existing_asset_ids
+        ]
+        skipped_existing_count = len(normalized_assets) - len(assets)
 
         context.data["assets"] = assets
         context.data["new_assets_count"] = len(assets)

--- a/workers/broll/steps/mark_job_completed.py
+++ b/workers/broll/steps/mark_job_completed.py
@@ -1,11 +1,11 @@
-from workers.broll.repository import BrollAssetRepository
+from workers.broll.repository import BrollAssetRepositoryProtocol
 from workers.common.pipeline import PipelineContext, PipelineStep
 
 
 class MarkJobCompletedStep(PipelineStep):
     step_name = "MarkJobCompletedStep"
 
-    def __init__(self, repository: BrollAssetRepository | None = None) -> None:
+    def __init__(self, repository: BrollAssetRepositoryProtocol | None = None) -> None:
         self._repository = repository
 
     async def _process(self, context: PipelineContext) -> None:

--- a/workers/broll/steps/persist_broll_asset.py
+++ b/workers/broll/steps/persist_broll_asset.py
@@ -1,11 +1,11 @@
-from workers.broll.repository import BrollAssetRepository
+from workers.broll.repository import BrollAssetRepositoryProtocol
 from workers.common.pipeline import PipelineContext, PipelineStep
 
 
 class PersistBrollAssetStep(PipelineStep):
     step_name = "PersistBrollAssetStep"
 
-    def __init__(self, repository: BrollAssetRepository | None = None) -> None:
+    def __init__(self, repository: BrollAssetRepositoryProtocol | None = None) -> None:
         self._repository = repository
 
     async def _process(self, context: PipelineContext) -> None:
@@ -15,6 +15,8 @@ class PersistBrollAssetStep(PipelineStep):
 
         frame_paths = context.data.get("frame_paths", {})
         embeddings = context.data.get("embeddings", {})
+        assets_to_store: list[dict[str, object]] = []
+        embeddings_to_store: list[list[float]] = []
         persisted_assets: list[dict[str, object]] = []
 
         for asset in context.data.get("assets", []):
@@ -23,12 +25,16 @@ class PersistBrollAssetStep(PipelineStep):
             if embedding is None:
                 continue
 
-            persisted_asset = await repository.upsert_broll_asset(
-                asset=asset,
-                embedding=embedding,
-                frame_path=frame_paths.get(asset_id),
-            )
+            assets_to_store.append(asset)
+            embeddings_to_store.append(list(embedding))
+            persisted_asset = dict(asset)
+            persisted_asset["embedding"] = list(embedding)
+            persisted_asset["frame_path"] = frame_paths.get(asset_id)
             persisted_assets.append(persisted_asset)
 
+        indexed_count = await repository.store_assets_batch(
+            assets_to_store,
+            embeddings_to_store,
+        )
         context.data["persisted_assets"] = persisted_assets
-        context.data["indexed_assets_count"] = len(persisted_assets)
+        context.data["indexed_assets_count"] = indexed_count

--- a/workers/common/sources/pexels.py
+++ b/workers/common/sources/pexels.py
@@ -1,4 +1,6 @@
 import os
+import asyncio
+import logging
 from typing import Any
 
 import httpx
@@ -7,25 +9,86 @@ import httpx
 class PexelsClient:
     base_url = "https://api.pexels.com/videos/search"
 
-    def __init__(self, api_key: str | None = None, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout: float = 30.0,
+        max_retries: int = 2,
+    ) -> None:
         self._api_key = api_key or os.getenv("PEXELS_API_KEY")
         self._timeout = timeout
+        self._max_retries = max_retries
+        self._logger = logging.getLogger(__name__)
 
     async def search_videos(
         self,
         query: str,
         per_page: int = 50,
+        *,
+        page: int = 1,
     ) -> list[dict[str, Any]]:
         if not self._api_key:
             raise RuntimeError("PEXELS_API_KEY is required to query Pexels.")
+        if not query.strip():
+            raise ValueError("Pexels search requires a non-empty query.")
+        if per_page < 1:
+            raise ValueError("Pexels search requires per_page >= 1.")
+        if page < 1:
+            raise ValueError("Pexels search requires page >= 1.")
 
         async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.get(
-                self.base_url,
-                params={"query": query, "per_page": per_page},
-                headers={"Authorization": self._api_key},
+            response = await self._request_with_retry(
+                client=client,
+                params={"query": query, "per_page": per_page, "page": page},
             )
 
         response.raise_for_status()
         payload = response.json()
         return payload.get("videos", [])
+
+    async def _request_with_retry(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        params: dict[str, Any],
+    ) -> httpx.Response:
+        for attempt in range(self._max_retries + 1):
+            response = await client.get(
+                self.base_url,
+                params=params,
+                headers={"Authorization": self._api_key},
+            )
+            status_code = getattr(response, "status_code", httpx.codes.OK)
+            if status_code != httpx.codes.TOO_MANY_REQUESTS:
+                return response
+
+            if attempt >= self._max_retries:
+                return response
+
+            retry_after = _resolve_retry_after(
+                getattr(response, "headers", {}).get("retry-after"),
+                default_seconds=float(attempt + 1),
+            )
+            self._logger.warning(
+                "Pexels rate limit hit for query=%s page=%s, sleeping %.2fs before retry.",
+                params.get("query"),
+                params.get("page", 1),
+                retry_after,
+            )
+            await asyncio.sleep(retry_after)
+
+        raise RuntimeError("Unexpected Pexels retry loop exit.")
+
+
+def _resolve_retry_after(
+    header_value: str | None,
+    *,
+    default_seconds: float,
+) -> float:
+    if header_value is None:
+        return default_seconds
+
+    try:
+        return max(float(header_value), 0.0)
+    except ValueError:
+        return default_seconds

--- a/workers/common/sources/pixabay.py
+++ b/workers/common/sources/pixabay.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import os
 from typing import Any
 
@@ -7,9 +9,16 @@ import httpx
 class PixabayClient:
     base_url = "https://pixabay.com/api/videos/"
 
-    def __init__(self, api_key: str | None = None, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout: float = 30.0,
+        max_retries: int = 2,
+    ) -> None:
         self._api_key = api_key or os.getenv("PIXABAY_API_KEY")
         self._timeout = timeout
+        self._max_retries = max_retries
+        self._logger = logging.getLogger(__name__)
 
     async def search_videos(
         self,
@@ -50,10 +59,7 @@ class PixabayClient:
         )
 
         async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.get(
-                self.base_url,
-                params=params,
-            )
+            response = await self._request_with_retry(client=client, params=params)
 
         response.raise_for_status()
         payload = response.json()
@@ -61,6 +67,38 @@ class PixabayClient:
         if not isinstance(hits, list):
             raise ValueError("Pixabay response payload is missing a valid hits list.")
         return [hit for hit in hits if isinstance(hit, dict)]
+
+    async def _request_with_retry(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        params: dict[str, Any],
+    ) -> httpx.Response:
+        for attempt in range(self._max_retries + 1):
+            response = await client.get(
+                self.base_url,
+                params=params,
+            )
+            status_code = getattr(response, "status_code", httpx.codes.OK)
+            if status_code != httpx.codes.TOO_MANY_REQUESTS:
+                return response
+
+            if attempt >= self._max_retries:
+                return response
+
+            retry_after = _resolve_retry_after(
+                getattr(response, "headers", {}).get("retry-after"),
+                default_seconds=float(attempt + 1),
+            )
+            self._logger.warning(
+                "Pixabay rate limit hit for query=%s page=%s, sleeping %.2fs before retry.",
+                params.get("q"),
+                params.get("page", 1),
+                retry_after,
+            )
+            await asyncio.sleep(retry_after)
+
+        raise RuntimeError("Unexpected Pixabay retry loop exit.")
 
     def _build_search_params(
         self,
@@ -106,3 +144,17 @@ class PixabayClient:
             }
         )
         return params
+
+
+def _resolve_retry_after(
+    header_value: str | None,
+    *,
+    default_seconds: float,
+) -> float:
+    if header_value is None:
+        return default_seconds
+
+    try:
+        return max(float(header_value), 0.0)
+    except ValueError:
+        return default_seconds

--- a/workers/tests/test_broll_steps.py
+++ b/workers/tests/test_broll_steps.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from backend.app.embedding import GeminiEmbeddingBackend
 from workers.broll import BrollIndexingPipeline
-from workers.broll.repository import InMemoryBrollAssetRepository
+from workers.broll.repository import BrollAssetRepository, InMemoryBrollAssetRepository
 from workers.broll.steps import (
     DiscoverAssetStep,
     FetchAssetMetadataStep,
@@ -13,6 +15,7 @@ from workers.broll.steps import download_preview_frame as download_preview_frame
 from workers.common.sources import PixabayClient
 import workers.common.sources.pixabay as pixabay_source_module
 from workers.common.pipeline import PipelineContext
+from scripts import seed_broll as seed_broll_module
 
 
 class FakeEmbeddingBackend:
@@ -161,6 +164,131 @@ class RecordingPixabayAsyncClient:
         }
         return FakePixabayApiResponse(
             {"hits": [{"id": 987}, "ignore-me", {"id": 654}]}
+        )
+
+
+class FakeTransaction:
+    async def __aenter__(self) -> "FakeTransaction":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FakePoolAcquire:
+    def __init__(self, connection: "RecordingRepositoryConnection") -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> "RecordingRepositoryConnection":
+        return self._connection
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FakePool:
+    def __init__(self, connection: "RecordingRepositoryConnection") -> None:
+        self._connection = connection
+        self.closed = False
+
+    def acquire(self) -> FakePoolAcquire:
+        return FakePoolAcquire(self._connection)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class RecordingRepositoryConnection:
+    def __init__(
+        self,
+        *,
+        fetch_rows: list[dict[str, object]] | None = None,
+        fetchval_result: int = 0,
+    ) -> None:
+        self.fetch_rows = fetch_rows or []
+        self.fetchval_result = fetchval_result
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.executemany_calls: list[tuple[str, list[tuple[object, ...]]]] = []
+
+    async def fetch(self, query: str, *params: object) -> list[dict[str, object]]:
+        self.fetch_calls.append((query, params))
+        return list(self.fetch_rows)
+
+    async def fetchrow(
+        self,
+        query: str,
+        *params: object,
+    ) -> dict[str, object] | None:
+        self.fetchrow_calls.append((query, params))
+        return {"exists": 1} if self.fetch_rows else None
+
+    async def fetchval(self, query: str, *params: object) -> int:
+        self.fetchval_calls.append((query, params))
+        return self.fetchval_result
+
+    async def execute(self, query: str, *params: object) -> str:
+        self.execute_calls.append((query, params))
+        return "OK"
+
+    async def executemany(
+        self,
+        query: str,
+        records: list[tuple[object, ...]],
+    ) -> None:
+        self.executemany_calls.append((query, list(records)))
+
+    def transaction(self) -> FakeTransaction:
+        return FakeTransaction()
+
+
+class FakeAsyncpgModule:
+    def __init__(self, pool: FakePool) -> None:
+        self._pool = pool
+        self.create_pool_calls: list[dict[str, object]] = []
+
+    async def create_pool(self, **kwargs: object) -> FakePool:
+        self.create_pool_calls.append(dict(kwargs))
+        return self._pool
+
+
+class FakeSeedRepository:
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeSeedPipeline:
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, dict[str, object]]] = []
+
+    async def run(
+        self,
+        query: str,
+        *,
+        conf: dict[str, object],
+        category: str | None = None,
+        job_id: str | None = None,
+    ) -> SimpleNamespace:
+        self.queries.append((query, conf))
+        return SimpleNamespace(
+            failed_step=None,
+            error=None,
+            data={
+                "discovered_assets_count": 12,
+                "new_assets_count": 7,
+                "indexed_assets_count": 7,
+                "last_discovery_page": 3,
+            },
         )
 
 
@@ -593,3 +721,194 @@ def test_broll_indexing_pipeline_runs_end_to_end_with_stubs() -> None:
     assert context.data["job_artifacts"]["duplicate_asset_count"] == 0
     assert context.data["job_artifacts"]["embedding_error_count"] == 0
     assert len(repository.stored_assets) == 1
+
+
+def test_broll_asset_repository_bulk_check_existing_returns_matching_asset_ids() -> None:
+    connection = RecordingRepositoryConnection(
+        fetch_rows=[
+            {"source": "pexels", "source_asset_id": "123"},
+            {"source": "pixabay", "source_asset_id": "456"},
+        ]
+    )
+    pool = FakePool(connection)
+    asyncpg_module = FakeAsyncpgModule(pool)
+    repository = BrollAssetRepository("postgres://example.test/cerul")
+
+    with patch("workers.broll.repository._import_asyncpg", return_value=asyncpg_module):
+        existing_ids = asyncio.run(
+            repository.bulk_check_existing(
+                [
+                    {
+                        "id": "pexels_123",
+                        "source": "pexels",
+                        "source_asset_id": "123",
+                    },
+                    {
+                        "id": "pixabay_456",
+                        "source": "pixabay",
+                        "source_asset_id": "456",
+                    },
+                    {
+                        "id": "pexels_999",
+                        "source": "pexels",
+                        "source_asset_id": "999",
+                    },
+                ]
+            )
+        )
+
+    assert existing_ids == {"pexels_123", "pixabay_456"}
+    assert len(connection.fetch_calls) == 1
+    _, params = connection.fetch_calls[0]
+    assert list(params[0]) == ["pexels", "pixabay", "pexels"]
+    assert list(params[1]) == ["123", "456", "999"]
+
+
+def test_broll_asset_repository_store_assets_batch_upserts_records() -> None:
+    connection = RecordingRepositoryConnection()
+    pool = FakePool(connection)
+    asyncpg_module = FakeAsyncpgModule(pool)
+    repository = BrollAssetRepository("postgres://example.test/cerul")
+    assets = [
+        {
+            "id": "pexels_123",
+            "source": "pexels",
+            "source_asset_id": "123",
+            "source_url": "https://www.pexels.com/video/123/",
+            "video_url": "https://cdn.pexels.com/videos/123.mp4",
+            "thumbnail_url": "https://images.pexels.com/videos/123.jpeg",
+            "duration": 14,
+            "title": "Mountain Dawn",
+            "description": "Golden hour drone shot",
+            "tags": ["mountain", "sunrise"],
+            "license": "Pexels License",
+            "creator": "Avery",
+            "metadata": {"query": "aerial mountain sunrise"},
+        },
+        {
+            "id": "pixabay_456",
+            "source": "pixabay",
+            "source_asset_id": "456",
+            "source_url": "https://pixabay.com/videos/id-456/",
+            "video_url": "https://cdn.pixabay.com/videos/456.mp4",
+            "thumbnail_url": "https://cdn.pixabay.com/video/456.jpg",
+            "duration_seconds": 21,
+            "title": "City Lights",
+            "description": "",
+            "tags": ["city", "night"],
+            "license": "Pixabay License",
+            "creator": "Riley",
+            "metadata": {"query": "tokyo neon streets night"},
+        },
+    ]
+
+    with patch("workers.broll.repository._import_asyncpg", return_value=asyncpg_module):
+        stored_count = asyncio.run(
+            repository.store_assets_batch(
+                assets,
+                [
+                    [0.1, 0.2, 0.3],
+                    [0.4, 0.5, 0.6],
+                ],
+            )
+        )
+
+    assert stored_count == 2
+    assert len(connection.executemany_calls) == 1
+    query, records = connection.executemany_calls[0]
+    assert "ON CONFLICT (source, source_asset_id) DO UPDATE" in query
+    assert len(records) == 2
+    assert records[0][0:4] == (
+        "pexels",
+        "123",
+        "https://www.pexels.com/video/123/",
+        "https://cdn.pexels.com/videos/123.mp4",
+    )
+    assert records[0][5] == 14
+    assert records[0][8] == ["mountain", "sunrise"]
+    assert json.loads(records[0][11]) == {"query": "aerial mountain sunrise"}
+    assert records[0][12] == "[0.1,0.2,0.3]"
+
+
+def test_seed_broll_resume_skips_completed_queries(tmp_path) -> None:
+    query_file = tmp_path / "queries.txt"
+    query_file.write_text(
+        "aerial mountain sunrise\nocean waves crashing rocks\n",
+        encoding="utf-8",
+    )
+    state_path = tmp_path / ".seed_broll_state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "aerial mountain sunrise": {
+                    "status": "completed",
+                    "assets_found": 10,
+                    "assets_indexed": 8,
+                    "last_page": 2,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    fake_pipeline = FakeSeedPipeline()
+    args = SimpleNamespace(
+        query=None,
+        file=str(query_file),
+        source="all",
+        per_page=50,
+        max_pages=10,
+        resume=True,
+        dry_run=False,
+        db_url="postgres://example.test/cerul",
+    )
+
+    with patch.object(seed_broll_module, "BrollAssetRepository", FakeSeedRepository):
+        result = asyncio.run(
+            seed_broll_module.run_seed(
+                args,
+                state_path=state_path,
+                pipeline_factory=lambda repository: fake_pipeline,
+            )
+        )
+
+    updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert result == 0
+    assert fake_pipeline.queries == [
+        (
+            "ocean waves crashing rocks",
+            {
+                "sources": ["pexels", "pixabay"],
+                "per_page": 50,
+                "max_pages": 10,
+            },
+        )
+    ]
+    assert updated_state["aerial mountain sunrise"]["status"] == "completed"
+    assert updated_state["ocean waves crashing rocks"]["status"] == "completed"
+    assert updated_state["ocean waves crashing rocks"]["last_page"] == 3
+
+
+def test_seed_broll_dry_run_produces_no_side_effects(tmp_path) -> None:
+    query_file = tmp_path / "queries.txt"
+    query_file.write_text("tokyo neon streets night\n", encoding="utf-8")
+    state_path = tmp_path / ".seed_broll_state.json"
+    args = SimpleNamespace(
+        query=None,
+        file=str(query_file),
+        source="pexels",
+        per_page=25,
+        max_pages=4,
+        resume=False,
+        dry_run=True,
+        db_url=None,
+    )
+
+    with patch.object(
+        seed_broll_module,
+        "BrollAssetRepository",
+        side_effect=AssertionError("dry-run should not create a repository"),
+    ):
+        result = asyncio.run(seed_broll_module.run_seed(args, state_path=state_path))
+
+    assert result == 0
+    assert not state_path.exists()


### PR DESCRIPTION
## Summary
- add an asyncpg-backed B-roll repository with pooled connections, batch existence checks, batch upserts, asset counting, and processing job completion updates
- update the B-roll pipeline and steps to default to the DB repository when available, paginate provider discovery, skip already indexed assets in bulk, and persist embeddings in batches
- rewrite the B-roll seed script for single-query and batch-file modes with resume and dry-run support, and add a curated 220-query seed list

## Affected directories
- `scripts/`
- `workers/broll/`
- `workers/common/sources/`
- `workers/tests/`

## Config changes
- no new environment variables
- `scripts/.seed_broll_state.json` is now ignored in `.gitignore`
- the seed script reads `--db-url` first and falls back to `DATABASE_URL`

## Testing status
- `pytest workers/tests/test_broll_steps.py -v`
- `python3 scripts/seed_broll.py --dry-run --query "aerial mountain sunrise"`
- `python3 -m py_compile scripts/seed_broll.py workers/broll/repository.py workers/broll/pipeline.py workers/broll/steps/discover_asset.py workers/broll/steps/fetch_asset_metadata.py workers/broll/steps/persist_broll_asset.py workers/common/sources/pexels.py workers/common/sources/pixabay.py`

## Screenshots
- N/A

## API changes
- no public API request/response changes

## Notes
- the existing migration still defines `broll_assets.embedding` as `VECTOR(512)` while the current Gemini embedding backend emits 768-dimensional vectors; this PR keeps migrations unchanged per task constraints, so schema alignment still needs to happen separately if the target database has not already been updated

