### PR TITLE
Add content discovery scheduler

### DIFF
--- a/workers/scheduler.py
+++ b/workers/scheduler.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import asyncpg
+
+from workers.common.sources import PexelsClient, PixabayClient, YouTubeClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContentSource:
+    id: str
+    slug: str
+    track: str
+    source_type: str
+    config: dict[str, Any]
+    sync_cursor: str | None
+    is_active: bool
+    cursor_storage: str
+
+
+class ContentScheduler:
+    _pixabay_option_names = (
+        "page",
+        "order",
+        "safesearch",
+        "video_type",
+        "category",
+        "editors_choice",
+        "min_width",
+        "min_height",
+        "lang",
+    )
+
+    def __init__(
+        self,
+        *,
+        youtube_client: YouTubeClient | None = None,
+        pexels_client: PexelsClient | None = None,
+        pixabay_client: PixabayClient | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._youtube_client = youtube_client or YouTubeClient()
+        self._pexels_client = pexels_client or PexelsClient()
+        self._pixabay_client = pixabay_client or PixabayClient()
+        self._logger = logger or logging.getLogger(__name__)
+        self._shutdown_event = asyncio.Event()
+
+    async def run_once(self, db: Any) -> dict[str, dict[str, int]]:
+        rows = await db.fetch(
+            """
+            SELECT *
+            FROM content_sources
+            WHERE is_active = TRUE
+            """
+        )
+        summary: dict[str, dict[str, int]] = {}
+
+        for row in rows:
+            source = self._normalize_source(row)
+            if source is None:
+                continue
+            if not source.is_active:
+                continue
+
+            summary[source.slug] = {"discovered": 0, "new_jobs": 0, "skipped": 0}
+
+            try:
+                discovered_items = await self._discover_items(source)
+                new_jobs = 0
+                skipped = 0
+
+                for item in discovered_items:
+                    source_item_id = self._get_source_item_id(source, item)
+                    job_exists = await db.fetchval(
+                        """
+                        SELECT 1
+                        FROM processing_jobs
+                        WHERE source_id = $1
+                          AND input_payload->>'source_item_id' = $2
+                        LIMIT 1
+                        """,
+                        source.id,
+                        source_item_id,
+                    )
+                    if job_exists:
+                        skipped += 1
+                        continue
+
+                    payload = self._build_input_payload(source, item, source_item_id)
+                    await db.execute(
+                        """
+                        INSERT INTO processing_jobs (
+                            track,
+                            source_id,
+                            job_type,
+                            status,
+                            input_payload
+                        )
+                        VALUES ($1, $2, $3, 'pending', $4::jsonb)
+                        """,
+                        source.track,
+                        source.id,
+                        self._get_job_type(source),
+                        json.dumps(payload, default=str),
+                    )
+                    new_jobs += 1
+
+                if discovered_items:
+                    latest_cursor = self._get_latest_cursor(source, discovered_items)
+                    if latest_cursor is not None:
+                        await self._update_sync_cursor(
+                            db,
+                            source_id=source.id,
+                            cursor=latest_cursor,
+                            cursor_storage=source.cursor_storage,
+                        )
+
+                summary[source.slug] = {
+                    "discovered": len(discovered_items),
+                    "new_jobs": new_jobs,
+                    "skipped": skipped,
+                }
+            except Exception:
+                self._logger.exception(
+                    "Failed to process content source '%s'.",
+                    source.slug,
+                )
+                continue
+
+        return summary
+
+    async def run_loop(self, db: Any, interval_seconds: int = 300) -> None:
+        self._shutdown_event.clear()
+        loop = asyncio.get_running_loop()
+        registered_signals: list[signal.Signals] = []
+
+        def _request_shutdown(signal_name: str) -> None:
+            self._logger.info("Received %s. Shutting down scheduler loop.", signal_name)
+            self._shutdown_event.set()
+
+        for signum in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(
+                    signum,
+                    _request_shutdown,
+                    signum.name,
+                )
+                registered_signals.append(signum)
+            except (NotImplementedError, RuntimeError):
+                continue
+
+        try:
+            while not self._shutdown_event.is_set():
+                summary = await self.run_once(db)
+                self._logger.info("Content discovery summary: %s", summary)
+
+                if self._shutdown_event.is_set():
+                    break
+
+                try:
+                    await asyncio.wait_for(
+                        self._shutdown_event.wait(),
+                        timeout=interval_seconds,
+                    )
+                except asyncio.TimeoutError:
+                    continue
+        finally:
+            for signum in registered_signals:
+                try:
+                    loop.remove_signal_handler(signum)
+                except RuntimeError:
+                    continue
+
+    def request_shutdown(self) -> None:
+        self._shutdown_event.set()
+
+    async def _discover_items(self, source: ContentSource) -> list[dict[str, Any]]:
+        if source.track == "knowledge" and source.source_type == "youtube":
+            return await self._discover_youtube_items(source)
+        if source.track == "broll" and source.source_type == "pexels":
+            return await self._discover_pexels_items(source)
+        if source.track == "broll" and source.source_type == "pixabay":
+            return await self._discover_pixabay_items(source)
+        raise ValueError(
+            f"Unsupported content source '{source.slug}' "
+            f"({source.track}/{source.source_type})."
+        )
+
+    async def _discover_youtube_items(
+        self,
+        source: ContentSource,
+    ) -> list[dict[str, Any]]:
+        channel_id = self._require_config_value(source, "channel_id")
+        max_results = self._coerce_int(source.config.get("max_results"), default=25)
+        videos = await self._youtube_client.search_channel_videos(
+            channel_id,
+            max_results=max_results,
+        )
+        if source.sync_cursor is None:
+            return videos
+
+        cursor_dt = self._parse_datetime(source.sync_cursor)
+        if cursor_dt is None:
+            self._logger.warning(
+                "Ignoring invalid sync_cursor for source '%s': %s",
+                source.slug,
+                source.sync_cursor,
+            )
+            return videos
+
+        filtered_videos: list[dict[str, Any]] = []
+        for video in videos:
+            published_at = self._parse_datetime(
+                self._coerce_string(video.get("published_at"))
+            )
+            if published_at is None:
+                continue
+            if published_at > cursor_dt:
+                filtered_videos.append(video)
+        return filtered_videos
+
+    async def _discover_pexels_items(
+        self,
+        source: ContentSource,
+    ) -> list[dict[str, Any]]:
+        query = self._require_config_value(source, "query")
+        per_page = self._coerce_int(source.config.get("per_page"), default=50)
+        items = await self._pexels_client.search_videos(query, per_page=per_page)
+        return self._filter_items_by_id(source, items)
+
+    async def _discover_pixabay_items(
+        self,
+        source: ContentSource,
+    ) -> list[dict[str, Any]]:
+        query = self._require_config_value(source, "query")
+        per_page = self._coerce_int(source.config.get("per_page"), default=50)
+        search_kwargs: dict[str, Any] = {
+            "query": query,
+            "per_page": per_page,
+        }
+        for option_name in self._pixabay_option_names:
+            if option_name in source.config:
+                search_kwargs[option_name] = source.config[option_name]
+
+        items = await self._pixabay_client.search_videos(**search_kwargs)
+        return self._filter_items_by_id(source, items)
+
+    def _filter_items_by_id(
+        self,
+        source: ContentSource,
+        items: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        if source.sync_cursor is None:
+            return items
+
+        filtered_items: list[dict[str, Any]] = []
+        for item in items:
+            source_item_id = self._get_source_item_id(source, item)
+            if self._is_after_cursor(source_item_id, source.sync_cursor):
+                filtered_items.append(item)
+        return filtered_items
+
+    def _build_input_payload(
+        self,
+        source: ContentSource,
+        item: dict[str, Any],
+        source_item_id: str,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "track": source.track,
+            "source_slug": source.slug,
+            "source_type": source.source_type,
+            "source_item_id": source_item_id,
+            "item": dict(item),
+        }
+
+        if source.track == "knowledge":
+            video_id = self._coerce_string(
+                item.get("source_video_id") or item.get("video_id") or item.get("id")
+            )
+            if video_id is None:
+                raise ValueError(
+                    f"Knowledge item for source '{source.slug}' is missing video_id."
+                )
+            payload["video_id"] = video_id
+            payload["source_metadata"] = dict(item)
+            return payload
+
+        payload["query"] = self._coerce_string(source.config.get("query"))
+        if source.config.get("category") is not None:
+            payload["category"] = self._coerce_string(source.config.get("category"))
+        payload["raw_asset"] = {
+            "source": source.source_type,
+            "payload": dict(item),
+        }
+        return payload
+
+    def _get_job_type(self, source: ContentSource) -> str:
+        if source.track == "knowledge":
+            return "index_video"
+        return "index_asset"
+
+    def _get_latest_cursor(
+        self,
+        source: ContentSource,
+        items: list[dict[str, Any]],
+    ) -> str | None:
+        if source.source_type == "youtube":
+            latest_item = max(
+                items,
+                key=lambda item: self._parse_datetime(
+                    self._coerce_string(item.get("published_at"))
+                )
+                or datetime.min.replace(tzinfo=UTC),
+            )
+            return self._coerce_string(latest_item.get("published_at"))
+
+        latest_item = max(
+            items,
+            key=lambda item: self._cursor_sort_key(
+                self._get_source_item_id(source, item)
+            ),
+        )
+        return self._get_source_item_id(source, latest_item)
+
+    async def _update_sync_cursor(
+        self,
+        db: Any,
+        *,
+        source_id: str,
+        cursor: str,
+        cursor_storage: str,
+    ) -> None:
+        if cursor_storage == "metadata":
+            await db.execute(
+                """
+                UPDATE content_sources
+                SET metadata = jsonb_set(
+                    COALESCE(metadata, '{}'::jsonb),
+                    '{sync_cursor}',
+                    to_jsonb($1::text),
+                    true
+                )
+                WHERE id = $2
+                """,
+                cursor,
+                source_id,
+            )
+            return
+
+        await db.execute(
+            """
+            UPDATE content_sources
+            SET sync_cursor = $1
+            WHERE id = $2
+            """,
+            cursor,
+            source_id,
+        )
+
+    def _normalize_source(self, row: Any) -> ContentSource | None:
+        source_row = dict(row)
+        config_value = self._coerce_mapping(source_row.get("config"))
+        metadata_value = self._coerce_mapping(source_row.get("metadata"))
+        raw_config = config_value if config_value else metadata_value
+        config = dict(raw_config) if raw_config else {}
+
+        slug = self._coerce_string(source_row.get("slug"))
+        track = self._coerce_string(source_row.get("track"))
+        source_id = self._coerce_string(source_row.get("id"))
+        if slug is None or track is None or source_id is None:
+            self._logger.warning("Skipping malformed content source row: %s", source_row)
+            return None
+
+        if track not in {"broll", "knowledge"}:
+            self._logger.warning(
+                "Skipping unsupported content source '%s' with track '%s'.",
+                slug,
+                track,
+            )
+            return None
+
+        source_type = (
+            self._coerce_string(source_row.get("source_type"))
+            or self._coerce_string(config.get("source_type"))
+            or self._infer_source_type(track, slug, source_row, config)
+        )
+        if source_type is None:
+            self._logger.warning(
+                "Skipping content source '%s' because source_type could not be inferred.",
+                slug,
+            )
+            return None
+
+        sync_cursor = self._coerce_string(source_row.get("sync_cursor")) or self._coerce_string(
+            config.get("sync_cursor")
+        )
+        cursor_storage = "column" if "sync_cursor" in source_row else "metadata"
+        return ContentSource(
+            id=source_id,
+            slug=slug,
+            track=track,
+            source_type=source_type,
+            config=config,
+            sync_cursor=sync_cursor,
+            is_active=bool(source_row.get("is_active", True)),
+            cursor_storage=cursor_storage,
+        )
+
+    def _infer_source_type(
+        self,
+        track: str,
+        slug: str,
+        row: dict[str, Any],
+        config: dict[str, Any],
+    ) -> str | None:
+        for candidate_key in ("provider", "source", "source_name"):
+            candidate = self._coerce_string(config.get(candidate_key))
+            if candidate:
+                return candidate
+
+        base_url = self._coerce_string(row.get("base_url")) or ""
+        slug_lower = slug.lower()
+        base_url_lower = base_url.lower()
+
+        if track == "knowledge":
+            return "youtube"
+        if "pexels" in slug_lower or "pexels" in base_url_lower:
+            return "pexels"
+        if "pixabay" in slug_lower or "pixabay" in base_url_lower:
+            return "pixabay"
+        return None
+
+    def _get_source_item_id(
+        self,
+        source: ContentSource,
+        item: dict[str, Any],
+    ) -> str:
+        if source.source_type == "youtube":
+            source_item_id = self._coerce_string(
+                item.get("source_video_id") or item.get("video_id") or item.get("id")
+            )
+        else:
+            raw_identifier = item.get("id")
+            source_item_id = self._coerce_string(raw_identifier)
+            if source_item_id is None and raw_identifier is not None:
+                source_item_id = str(raw_identifier)
+
+        if source_item_id is None:
+            raise ValueError(
+                f"Discovered item for source '{source.slug}' is missing a source id."
+            )
+        return source_item_id
+
+    def _require_config_value(self, source: ContentSource, key: str) -> str:
+        value = self._coerce_string(source.config.get(key))
+        if value is None:
+            raise ValueError(f"Content source '{source.slug}' is missing config.{key}.")
+        return value
+
+    def _is_after_cursor(self, source_item_id: str, sync_cursor: str) -> bool:
+        current_value = self._cursor_sort_key(source_item_id)
+        cursor_value = self._cursor_sort_key(sync_cursor)
+        return current_value > cursor_value
+
+    def _cursor_sort_key(self, value: str) -> tuple[int, Any]:
+        try:
+            return (1, int(value))
+        except (TypeError, ValueError):
+            return (0, value)
+
+    def _coerce_int(self, value: Any, *, default: int) -> int:
+        if isinstance(value, bool):
+            return default
+        if isinstance(value, int):
+            return value
+        if value is None:
+            return default
+        try:
+            return int(str(value).strip())
+        except (TypeError, ValueError):
+            return default
+
+    def _coerce_string(self, value: Any) -> str | None:
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return None
+
+    def _coerce_mapping(self, value: Any) -> dict[str, Any] | None:
+        if isinstance(value, dict):
+            return dict(value)
+        if not isinstance(value, str):
+            return None
+
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(decoded, dict):
+            return {str(key): item for key, item in decoded.items()}
+        return None
+
+    def _parse_datetime(self, value: str | None) -> datetime | None:
+        if value is None:
+            return None
+        normalized_value = value.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized_value)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the Cerul content discovery scheduler.",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run a single discovery scan and exit.",
+    )
+    parser.add_argument(
+        "--interval-seconds",
+        type=int,
+        default=300,
+        help="Polling interval in loop mode.",
+    )
+    parser.add_argument(
+        "--database-url",
+        help="Optional asyncpg DSN. Falls back to DATABASE_URL.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    database_url = (args.database_url or os.getenv("DATABASE_URL") or "").strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL is required.")
+
+    connection = await asyncpg.connect(database_url)
+    scheduler = ContentScheduler()
+
+    try:
+        if args.once:
+            summary = await scheduler.run_once(connection)
+            logger.info("Content discovery summary: %s", summary)
+        else:
+            await scheduler.run_loop(connection, interval_seconds=args.interval_seconds)
+    finally:
+        await connection.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/workers/tests/test_scheduler.py
+++ b/workers/tests/test_scheduler.py
@@ -1,0 +1,367 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+from workers.scheduler import ContentScheduler
+
+
+class FakeDB:
+    def __init__(
+        self,
+        *,
+        sources: list[dict[str, object]],
+        existing_jobs: set[tuple[str, str]] | None = None,
+    ) -> None:
+        self._sources = list(sources)
+        self._existing_jobs = set(existing_jobs or set())
+        self.inserted_jobs: list[dict[str, object]] = []
+        self.updated_cursors: dict[str, str] = {}
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetch(self, query: str, *params: object) -> list[dict[str, object]]:
+        self.fetch_calls.append((query, params))
+        return list(self._sources)
+
+    async def fetchval(self, query: str, *params: object) -> object | None:
+        self.fetchval_calls.append((query, params))
+        source_id, source_item_id = params
+        if (str(source_id), str(source_item_id)) in self._existing_jobs:
+            return 1
+        return None
+
+    async def execute(self, query: str, *params: object) -> str:
+        self.execute_calls.append((query, params))
+
+        if "INSERT INTO processing_jobs" in query:
+            track, source_id, job_type, payload_json = params
+            payload = json.loads(str(payload_json))
+            self.inserted_jobs.append(
+                {
+                    "track": track,
+                    "source_id": source_id,
+                    "job_type": job_type,
+                    "payload": payload,
+                }
+            )
+            self._existing_jobs.add((str(source_id), str(payload["source_item_id"])))
+            return "INSERT 0 1"
+
+        if "SET sync_cursor = $1" in query:
+            cursor, source_id = params
+            self.updated_cursors[str(source_id)] = str(cursor)
+            return "UPDATE 1"
+
+        if "SET metadata = jsonb_set" in query:
+            cursor, source_id = params
+            self.updated_cursors[str(source_id)] = str(cursor)
+            return "UPDATE 1"
+
+        raise AssertionError(f"Unexpected SQL: {query}")
+
+
+def make_source(
+    *,
+    source_id: str,
+    slug: str,
+    track: str,
+    source_type: str,
+    config: dict[str, object],
+    sync_cursor: str | None = None,
+    is_active: bool = True,
+) -> dict[str, object]:
+    return {
+        "id": source_id,
+        "slug": slug,
+        "track": track,
+        "source_type": source_type,
+        "config": config,
+        "sync_cursor": sync_cursor,
+        "is_active": is_active,
+    }
+
+
+def test_run_once_creates_jobs_for_new_content_items() -> None:
+    db = FakeDB(
+        sources=[
+            make_source(
+                source_id="source-yt",
+                slug="openai-channel",
+                track="knowledge",
+                source_type="youtube",
+                config={"channel_id": "channel-42"},
+            ),
+            make_source(
+                source_id="source-pexels",
+                slug="cinematic-drone",
+                track="broll",
+                source_type="pexels",
+                config={"query": "cinematic drone"},
+            ),
+            make_source(
+                source_id="source-pixabay",
+                slug="ocean-waves",
+                track="broll",
+                source_type="pixabay",
+                config={"query": "ocean waves"},
+            ),
+        ]
+    )
+    youtube_client = AsyncMock()
+    youtube_client.search_channel_videos.return_value = [
+        {
+            "source_video_id": "video-001",
+            "video_id": "video-001",
+            "title": "OpenAI keynote",
+            "published_at": "2026-03-10T12:00:00Z",
+        }
+    ]
+    pexels_client = AsyncMock()
+    pexels_client.search_videos.return_value = [
+        {
+            "id": 501,
+            "url": "https://www.pexels.com/video/501/",
+            "duration": 14,
+        }
+    ]
+    pixabay_client = AsyncMock()
+    pixabay_client.search_videos.return_value = [
+        {
+            "id": 901,
+            "pageURL": "https://pixabay.com/videos/id-901/",
+            "duration": 8,
+        }
+    ]
+
+    scheduler = ContentScheduler(
+        youtube_client=youtube_client,
+        pexels_client=pexels_client,
+        pixabay_client=pixabay_client,
+    )
+
+    summary = asyncio.run(scheduler.run_once(db))
+
+    assert summary == {
+        "openai-channel": {"discovered": 1, "new_jobs": 1, "skipped": 0},
+        "cinematic-drone": {"discovered": 1, "new_jobs": 1, "skipped": 0},
+        "ocean-waves": {"discovered": 1, "new_jobs": 1, "skipped": 0},
+    }
+    assert len(db.inserted_jobs) == 3
+    assert db.inserted_jobs[0]["job_type"] == "index_video"
+    assert db.inserted_jobs[0]["payload"]["source_item_id"] == "video-001"
+    assert db.inserted_jobs[0]["payload"]["video_id"] == "video-001"
+    assert db.inserted_jobs[1]["job_type"] == "index_asset"
+    assert db.inserted_jobs[1]["payload"]["source_item_id"] == "501"
+    assert db.inserted_jobs[1]["payload"]["query"] == "cinematic drone"
+    assert db.inserted_jobs[2]["payload"]["source_item_id"] == "901"
+    assert db.inserted_jobs[2]["payload"]["raw_asset"]["source"] == "pixabay"
+    youtube_client.search_channel_videos.assert_awaited_once_with(
+        "channel-42",
+        max_results=25,
+    )
+    pexels_client.search_videos.assert_awaited_once_with("cinematic drone", per_page=50)
+    pixabay_client.search_videos.assert_awaited_once_with(
+        query="ocean waves",
+        per_page=50,
+    )
+
+
+def test_run_once_skips_existing_jobs() -> None:
+    db = FakeDB(
+        sources=[
+            make_source(
+                source_id="source-pexels",
+                slug="city-lights",
+                track="broll",
+                source_type="pexels",
+                config={"query": "city lights"},
+            )
+        ],
+        existing_jobs={("source-pexels", "777")},
+    )
+    pexels_client = AsyncMock()
+    pexels_client.search_videos.return_value = [{"id": 777, "url": "https://example.com/777"}]
+
+    scheduler = ContentScheduler(
+        youtube_client=AsyncMock(),
+        pexels_client=pexels_client,
+        pixabay_client=AsyncMock(),
+    )
+
+    summary = asyncio.run(scheduler.run_once(db))
+
+    assert summary == {
+        "city-lights": {"discovered": 1, "new_jobs": 0, "skipped": 1},
+    }
+    assert db.inserted_jobs == []
+    assert db.updated_cursors == {"source-pexels": "777"}
+
+
+def test_run_once_updates_sync_cursor_after_successful_scan() -> None:
+    db = FakeDB(
+        sources=[
+            make_source(
+                source_id="source-yt",
+                slug="research-talks",
+                track="knowledge",
+                source_type="youtube",
+                config={"channel_id": "channel-99"},
+                sync_cursor="2026-03-08T00:00:00Z",
+            )
+        ]
+    )
+    youtube_client = AsyncMock()
+    youtube_client.search_channel_videos.return_value = [
+        {
+            "source_video_id": "video-010",
+            "video_id": "video-010",
+            "published_at": "2026-03-09T12:00:00Z",
+        },
+        {
+            "source_video_id": "video-011",
+            "video_id": "video-011",
+            "published_at": "2026-03-10T18:30:00Z",
+        },
+    ]
+
+    scheduler = ContentScheduler(
+        youtube_client=youtube_client,
+        pexels_client=AsyncMock(),
+        pixabay_client=AsyncMock(),
+    )
+
+    summary = asyncio.run(scheduler.run_once(db))
+
+    assert summary == {
+        "research-talks": {"discovered": 2, "new_jobs": 2, "skipped": 0},
+    }
+    assert db.updated_cursors == {"source-yt": "2026-03-10T18:30:00Z"}
+
+
+def test_run_once_handles_source_client_errors_gracefully() -> None:
+    db = FakeDB(
+        sources=[
+            make_source(
+                source_id="source-pexels",
+                slug="broken-pexels",
+                track="broll",
+                source_type="pexels",
+                config={"query": "broken"},
+            ),
+            make_source(
+                source_id="source-yt",
+                slug="healthy-youtube",
+                track="knowledge",
+                source_type="youtube",
+                config={"channel_id": "channel-42"},
+            ),
+        ]
+    )
+    pexels_client = AsyncMock()
+    pexels_client.search_videos.side_effect = RuntimeError("pexels unavailable")
+    youtube_client = AsyncMock()
+    youtube_client.search_channel_videos.return_value = [
+        {
+            "source_video_id": "video-001",
+            "video_id": "video-001",
+            "published_at": "2026-03-10T12:00:00Z",
+        }
+    ]
+
+    scheduler = ContentScheduler(
+        youtube_client=youtube_client,
+        pexels_client=pexels_client,
+        pixabay_client=AsyncMock(),
+    )
+
+    summary = asyncio.run(scheduler.run_once(db))
+
+    assert summary == {
+        "broken-pexels": {"discovered": 0, "new_jobs": 0, "skipped": 0},
+        "healthy-youtube": {"discovered": 1, "new_jobs": 1, "skipped": 0},
+    }
+    assert len(db.inserted_jobs) == 1
+    assert db.inserted_jobs[0]["source_id"] == "source-yt"
+
+
+def test_run_once_only_processes_active_sources() -> None:
+    db = FakeDB(
+        sources=[
+            make_source(
+                source_id="source-active",
+                slug="active-pixabay",
+                track="broll",
+                source_type="pixabay",
+                config={"query": "sunrise"},
+                is_active=True,
+            ),
+            make_source(
+                source_id="source-inactive",
+                slug="inactive-pixabay",
+                track="broll",
+                source_type="pixabay",
+                config={"query": "night city"},
+                is_active=False,
+            ),
+        ]
+    )
+    pixabay_client = AsyncMock()
+    pixabay_client.search_videos.return_value = [{"id": 111}]
+
+    scheduler = ContentScheduler(
+        youtube_client=AsyncMock(),
+        pexels_client=AsyncMock(),
+        pixabay_client=pixabay_client,
+    )
+
+    summary = asyncio.run(scheduler.run_once(db))
+
+    assert summary == {
+        "active-pixabay": {"discovered": 1, "new_jobs": 1, "skipped": 0},
+    }
+    pixabay_client.search_videos.assert_awaited_once_with(query="sunrise", per_page=50)
+    assert len(db.inserted_jobs) == 1
+    assert db.inserted_jobs[0]["source_id"] == "source-active"
+
+
+def test_run_once_supports_legacy_metadata_backed_sources() -> None:
+    db = FakeDB(
+        sources=[
+            {
+                "id": "legacy-yt",
+                "slug": "legacy-youtube",
+                "track": "knowledge",
+                "base_url": "https://www.youtube.com",
+                "metadata": json.dumps(
+                    {
+                        "channel_id": "channel-legacy",
+                        "sync_cursor": "2026-03-01T00:00:00Z",
+                    }
+                ),
+                "is_active": True,
+            }
+        ]
+    )
+    youtube_client = AsyncMock()
+    youtube_client.search_channel_videos.return_value = [
+        {
+            "source_video_id": "legacy-video-1",
+            "video_id": "legacy-video-1",
+            "published_at": "2026-03-10T12:00:00Z",
+        }
+    ]
+
+    scheduler = ContentScheduler(
+        youtube_client=youtube_client,
+        pexels_client=AsyncMock(),
+        pixabay_client=AsyncMock(),
+    )
+
+    summary = asyncio.run(scheduler.run_once(db))
+
+    assert summary == {
+        "legacy-youtube": {"discovered": 1, "new_jobs": 1, "skipped": 0},
+    }
+    assert len(db.inserted_jobs) == 1
+    assert db.updated_cursors == {"legacy-yt": "2026-03-10T12:00:00Z"}


### PR DESCRIPTION
## Summary
- add a content discovery scheduler that scans active sources and enqueues pending processing jobs
- support YouTube, Pexels, and Pixabay discovery with deduplication and sync cursor updates
- add scheduler tests covering new jobs, deduplication, cursor updates, error handling, and legacy metadata compatibility

## Affected Directories
- workers/

## Configuration
- no new environment variables

## Testing
- pytest workers/tests/test_scheduler.py workers/tests/test_youtube_client.py -q

## Screenshots
- not applicable

## API Examples
- not applicable