### PR TITLE
Fix Round 3 CI failures and review issues

### DIFF
--- a/scripts/seed_broll.py
+++ b/scripts/seed_broll.py
@@ -167,6 +167,9 @@ async def run_seed(
     completed_queries = [
         query for query in queries if state.get(query, {}).get("status") == "completed"
     ]
+    failed_queries = [
+        query for query in queries if state.get(query, {}).get("status") == "failed"
+    ]
     total_indexed = sum(
         int(state[query].get("assets_indexed", 0)) for query in completed_queries
     )
@@ -174,6 +177,9 @@ async def run_seed(
         f"Total: {total_indexed:,} assets indexed across "
         f"{len(completed_queries)} queries"
     )
+    if failed_queries:
+        print(f"Warning: {len(failed_queries)} queries failed")
+        return 1
     return 0
 
 

--- a/workers/requirements-test.txt
+++ b/workers/requirements-test.txt
@@ -1,2 +1,3 @@
 httpx>=0.28,<1
+asyncpg>=0.30,<1
 pytest>=8.4,<10

--- a/workers/scheduler.py
+++ b/workers/scheduler.py
@@ -8,7 +8,7 @@ import os
 import signal
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -329,7 +329,7 @@ class ContentScheduler:
                 key=lambda item: self._parse_datetime(
                     self._coerce_string(item.get("published_at"))
                 )
-                or datetime.min.replace(tzinfo=UTC),
+                or datetime.min.replace(tzinfo=timezone.utc),
             )
             return self._coerce_string(latest_item.get("published_at"))
 
@@ -503,7 +503,9 @@ class ContentScheduler:
         if isinstance(value, str):
             stripped = value.strip()
             return stripped or None
-        return None
+        if value is None:
+            return None
+        return str(value)
 
     def _coerce_mapping(self, value: Any) -> dict[str, Any] | None:
         if isinstance(value, dict):
@@ -528,8 +530,8 @@ class ContentScheduler:
         except ValueError:
             return None
         if parsed.tzinfo is None:
-            return parsed.replace(tzinfo=UTC)
-        return parsed.astimezone(UTC)
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
 
 
 async def main() -> None:

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -250,6 +250,7 @@ class JobWorker:
         conn = await asyncpg.connect(self.db_url)
 
         try:
+            await self.release_locked_jobs(conn)
             while not self._shutdown_event.is_set():
                 job = await self.claim_job(conn)
                 if job is None:


### PR DESCRIPTION
## Summary
- Add `asyncpg` to `workers/requirements-test.txt` — fixes Workers Test CI failures in PRs #49 and #50
- Replace `datetime.UTC` with `timezone.utc` in scheduler for broader Python compatibility
- Fix UUID handling in `ContentScheduler._coerce_string()` — asyncpg returns `uuid.UUID` objects, not strings
- Add stale job recovery on worker startup — releases jobs stuck in `running` from previous crashes
- Return non-zero exit code from `seed_broll.py` when batch queries partially fail

## Test plan
- [x] `pytest workers/tests -v` — 58 passed, 0 failures
- [x] `pytest backend/tests -v` — 70 passed, 0 failures
- [x] `pnpm test` (vitest) — 37 passed
- [x] `pnpm build` — successful
- [ ] CI should now pass Workers Test check

🤖 Generated with [Claude Code](https://claude.com/claude-code)