### PR TITLE
Fix social metadata coverage for search pages

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,7 +35,8 @@ Cerul's web app is ready to deploy to Vercel as a subdirectory app.
 
 - set the Vercel project Root Directory to `frontend`
 - keep `frontend/vercel.json` as the project-level Vercel config
-- optional env override: `NEXT_PUBLIC_SITE_URL=https://your-domain.example`
+- set `NEXT_PUBLIC_SITE_URL` to your canonical public origin when using a custom domain
+- make sure `NEXT_PUBLIC_SITE_URL` matches the final host that users and crawlers land on, so canonical URLs and social cards do not point at a redirecting domain
 
 If no custom public URL is provided, the app falls back to Vercel system environment
 variables for metadata, canonical URLs, `robots.txt`, and `sitemap.xml`.

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import {
+  defaultOpenGraphImages,
+  defaultTwitterImages,
+} from "@/lib/social-metadata";
 import { getSiteOrigin } from "@/lib/site-url";
 import "./globals.css";
 
@@ -94,28 +98,14 @@ export const metadata: Metadata = {
     url: siteOrigin,
     siteName: "Cerul",
     type: "website",
-    images: [
-      {
-        url: "/og-image.png",
-        width: 1200,
-        height: 630,
-        alt: "Cerul — Video Search API for AI Agents",
-      },
-    ],
+    images: defaultOpenGraphImages,
   },
   twitter: {
     card: "summary_large_image",
     title: "Cerul",
     description:
       "Video understanding search API for AI agents. Search what is shown in videos, not just what is said.",
-    images: [
-      {
-        url: "/og-twitter.png",
-        width: 800,
-        height: 418,
-        alt: "Cerul — Video Search API for AI Agents",
-      },
-    ],
+    images: defaultTwitterImages,
   },
 };
 

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next";
 import { SearchDemo } from "@/components/search/search-demo";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import {
+  defaultOpenGraphImages,
+  defaultTwitterImages,
+} from "@/lib/social-metadata";
 import { canonicalUrl } from "@/lib/site-url";
 
 const description =
@@ -19,10 +23,13 @@ export const metadata: Metadata = {
     title: "Search Demo",
     description,
     url: searchDemoUrl,
+    images: defaultOpenGraphImages,
   },
   twitter: {
+    card: "summary_large_image",
     title: "Search Demo",
     description,
+    images: defaultTwitterImages,
   },
 };
 

--- a/frontend/lib/social-metadata.test.ts
+++ b/frontend/lib/social-metadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  SOCIAL_IMAGE_VERSION,
+  defaultOpenGraphImages,
+  defaultTwitterImages,
+} from "./social-metadata";
+
+describe("social metadata", () => {
+  it("adds a versioned Open Graph image URL", () => {
+    expect(defaultOpenGraphImages[0]).toMatchObject({
+      url: `/og-image.png?v=${SOCIAL_IMAGE_VERSION}`,
+      width: 1200,
+      height: 630,
+    });
+  });
+
+  it("adds a versioned Twitter image URL", () => {
+    expect(defaultTwitterImages[0]).toMatchObject({
+      url: `/og-twitter.png?v=${SOCIAL_IMAGE_VERSION}`,
+      width: 800,
+      height: 418,
+    });
+  });
+});

--- a/frontend/lib/social-metadata.ts
+++ b/frontend/lib/social-metadata.ts
@@ -1,0 +1,21 @@
+export const SOCIAL_IMAGE_VERSION = "20260314";
+
+const socialImageAlt = "Cerul - Video Search API for AI Agents";
+
+export const defaultOpenGraphImages = [
+  {
+    url: `/og-image.png?v=${SOCIAL_IMAGE_VERSION}`,
+    width: 1200,
+    height: 630,
+    alt: socialImageAlt,
+  },
+];
+
+export const defaultTwitterImages = [
+  {
+    url: `/og-twitter.png?v=${SOCIAL_IMAGE_VERSION}`,
+    width: 800,
+    height: 418,
+    alt: socialImageAlt,
+  },
+];


### PR DESCRIPTION
## Summary
- centralize default Open Graph and Twitter image metadata in a shared frontend helper
- restore `og:image`, `twitter:image`, and `summary_large_image` metadata for `/search`
- version social image URLs to make card refreshes deterministic after deploy
- document that `NEXT_PUBLIC_SITE_URL` should match the canonical public origin

## Affected Directories
- `frontend/app`
- `frontend/lib`
- `frontend/README.md`

## Env Vars / Configuration
- no new env vars
- existing `NEXT_PUBLIC_SITE_URL` should match the canonical public host used in production

## Testing Status
- `pnpm --dir frontend test`
- `pnpm --dir frontend lint`
- `pnpm --dir frontend build`

## Screenshots
- none

## API Changes
- none
