### PR TITLE
Refresh homepage social card metadata

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,7 @@ import { AgentDemoConsole } from "@/components/agent-demo-console";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import { getSiteOrigin } from "@/lib/site-url";
+import { homeOpenGraphImages, homeTwitterImages } from "@/lib/social-metadata";
 import {
   benchmarkRows,
   capabilityHighlights,
@@ -13,13 +14,31 @@ import {
   searchTracks,
 } from "@/lib/site";
 
+const homeDescription =
+  "Video understanding search API for AI agents. Search what is shown in videos, not just what is said.";
+
+const siteOrigin = getSiteOrigin();
+
 export const metadata: Metadata = {
+  description: homeDescription,
   alternates: {
     canonical: "/",
   },
+  openGraph: {
+    title: "Cerul",
+    description: homeDescription,
+    url: siteOrigin,
+    siteName: "Cerul",
+    type: "website",
+    images: homeOpenGraphImages,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Cerul",
+    description: homeDescription,
+    images: homeTwitterImages,
+  },
 };
-
-const siteOrigin = getSiteOrigin();
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -27,8 +46,7 @@ const jsonLd = {
   name: "Cerul",
   applicationCategory: "DeveloperApplication",
   operatingSystem: "Web",
-  description:
-    "Video understanding search API for AI agents. Search what is shown in videos, not just what is said.",
+  description: homeDescription,
   url: siteOrigin,
 };
 

--- a/frontend/lib/social-metadata.test.ts
+++ b/frontend/lib/social-metadata.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  HOME_SOCIAL_IMAGE_VERSION,
   SOCIAL_IMAGE_VERSION,
   defaultOpenGraphImages,
   defaultTwitterImages,
+  homeOpenGraphImages,
+  homeTwitterImages,
 } from "./social-metadata";
 
 describe("social metadata", () => {
@@ -17,6 +20,22 @@ describe("social metadata", () => {
   it("adds a versioned Twitter image URL", () => {
     expect(defaultTwitterImages[0]).toMatchObject({
       url: `/og-twitter.png?v=${SOCIAL_IMAGE_VERSION}`,
+      width: 800,
+      height: 418,
+    });
+  });
+
+  it("gives the homepage its own Open Graph image version", () => {
+    expect(homeOpenGraphImages[0]).toMatchObject({
+      url: `/og-image.png?v=${HOME_SOCIAL_IMAGE_VERSION}`,
+      width: 1200,
+      height: 630,
+    });
+  });
+
+  it("gives the homepage its own Twitter image version", () => {
+    expect(homeTwitterImages[0]).toMatchObject({
+      url: `/og-twitter.png?v=${HOME_SOCIAL_IMAGE_VERSION}`,
       width: 800,
       height: 418,
     });

--- a/frontend/lib/social-metadata.ts
+++ b/frontend/lib/social-metadata.ts
@@ -1,21 +1,31 @@
 export const SOCIAL_IMAGE_VERSION = "20260314";
+export const HOME_SOCIAL_IMAGE_VERSION = "20260315-home1";
 
 const socialImageAlt = "Cerul - Video Search API for AI Agents";
 
-export const defaultOpenGraphImages = [
-  {
-    url: `/og-image.png?v=${SOCIAL_IMAGE_VERSION}`,
-    width: 1200,
-    height: 630,
-    alt: socialImageAlt,
-  },
-];
+function createOpenGraphImages(version: string) {
+  return [
+    {
+      url: `/og-image.png?v=${version}`,
+      width: 1200,
+      height: 630,
+      alt: socialImageAlt,
+    },
+  ];
+}
 
-export const defaultTwitterImages = [
-  {
-    url: `/og-twitter.png?v=${SOCIAL_IMAGE_VERSION}`,
-    width: 800,
-    height: 418,
-    alt: socialImageAlt,
-  },
-];
+function createTwitterImages(version: string) {
+  return [
+    {
+      url: `/og-twitter.png?v=${version}`,
+      width: 800,
+      height: 418,
+      alt: socialImageAlt,
+    },
+  ];
+}
+
+export const defaultOpenGraphImages = createOpenGraphImages(SOCIAL_IMAGE_VERSION);
+export const defaultTwitterImages = createTwitterImages(SOCIAL_IMAGE_VERSION);
+export const homeOpenGraphImages = createOpenGraphImages(HOME_SOCIAL_IMAGE_VERSION);
+export const homeTwitterImages = createTwitterImages(HOME_SOCIAL_IMAGE_VERSION);


### PR DESCRIPTION
## Summary
- give the homepage its own social image version so `https://cerul.ai` can use a fresh card image cache key
- add explicit homepage `openGraph` and `twitter` metadata instead of relying only on shared layout metadata
- add tests covering the dedicated homepage social image version

## Affected Directories
- `frontend/app`
- `frontend/lib`

## Env Vars / Config
- None

## Testing
- `pnpm --dir frontend test`

## Screenshots
- N/A (metadata-only change)

## API Changes
- N/A
