### PR TITLE
Add YouTube keyword search client

### DIFF
--- a/workers/common/sources/youtube.py
+++ b/workers/common/sources/youtube.py
@@ -38,7 +38,7 @@ class YouTubeClient:
             "videos",
             {
                 "id": video_id,
-                "part": "snippet,contentDetails,status",
+                "part": "snippet,contentDetails,status,statistics",
             },
         )
         items = payload.get("items", [])
@@ -46,6 +46,35 @@ class YouTubeClient:
             raise LookupError(f"YouTube video not found: {video_id}")
 
         return self._normalize_video(items[0])
+
+    async def search_videos(
+        self,
+        query: str,
+        max_results: int = 25,
+        *,
+        published_after: str | None = None,
+        relevance_language: str | None = None,
+        video_duration: str | None = None,
+        event_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        query = query.strip()
+        if not query:
+            raise ValueError("query is required.")
+        if max_results <= 0:
+            raise ValueError("max_results must be greater than 0.")
+
+        ordered_video_ids = await self._search_video_ids(
+            {
+                "eventType": event_type,
+                "order": "relevance",
+                "publishedAfter": published_after,
+                "q": query,
+                "relevanceLanguage": relevance_language,
+                "videoDuration": video_duration,
+            },
+            max_results=max_results,
+        )
+        return await self._get_videos_by_ids(ordered_video_ids)
 
     async def search_channel_videos(
         self,
@@ -58,6 +87,21 @@ class YouTubeClient:
         if max_results <= 0:
             raise ValueError("max_results must be greater than 0.")
 
+        ordered_video_ids = await self._search_video_ids(
+            {
+                "channelId": channel_id,
+                "order": "date",
+            },
+            max_results=max_results,
+        )
+        return await self._get_videos_by_ids(ordered_video_ids)
+
+    async def _search_video_ids(
+        self,
+        params: dict[str, Any],
+        *,
+        max_results: int,
+    ) -> list[str]:
         ordered_video_ids: list[str] = []
         seen_video_ids: set[str] = set()
         next_page_token: str | None = None
@@ -67,12 +111,11 @@ class YouTubeClient:
             payload = await self._get_json(
                 "search",
                 {
-                    "channelId": channel_id,
                     "maxResults": min(remaining, 50),
-                    "order": "date",
                     "pageToken": next_page_token,
                     "part": "snippet",
                     "type": "video",
+                    **params,
                 },
             )
             items = payload.get("items", [])
@@ -89,6 +132,12 @@ class YouTubeClient:
             if next_page_token is None:
                 break
 
+        return ordered_video_ids
+
+    async def _get_videos_by_ids(
+        self,
+        ordered_video_ids: list[str],
+    ) -> list[dict[str, Any]]:
         if not ordered_video_ids:
             return []
 
@@ -100,7 +149,7 @@ class YouTubeClient:
                     "videos",
                     {
                         "id": ",".join(video_id_batch),
-                        "part": "snippet,contentDetails,status",
+                        "part": "snippet,contentDetails,status,statistics",
                     },
                 )
             ).get("items", [])
@@ -144,6 +193,7 @@ class YouTubeClient:
         snippet = payload.get("snippet") or {}
         content_details = payload.get("contentDetails") or {}
         status = payload.get("status") or {}
+        statistics = payload.get("statistics") or {}
         watch_url = self._build_watch_url(video_id)
         duration_seconds = self._parse_duration_seconds(content_details.get("duration"))
 
@@ -164,6 +214,8 @@ class YouTubeClient:
             "published_at": self._coerce_string(snippet.get("publishedAt")),
             "duration": duration_seconds,
             "duration_seconds": duration_seconds,
+            "view_count": self._coerce_int(statistics.get("viewCount")),
+            "like_count": self._coerce_int(statistics.get("likeCount")),
             "license": self._normalize_license(status.get("license")),
             "privacy_status": self._coerce_string(status.get("privacyStatus")),
             "embeddable": status.get("embeddable"),
@@ -230,6 +282,21 @@ class YouTubeClient:
             return None
         stripped = value.strip()
         return stripped or None
+
+    def _coerce_int(self, value: Any) -> int | None:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                return int(stripped)
+            except ValueError:
+                return None
+        return None
 
     def _build_watch_url(self, video_id: str) -> str:
         return f"https://www.youtube.com/watch?v={video_id}"

--- a/workers/tests/test_youtube_client.py
+++ b/workers/tests/test_youtube_client.py
@@ -54,6 +54,10 @@ def test_get_video_metadata_normalizes_response() -> None:
                             "liveBroadcastContent": "none",
                         },
                         "contentDetails": {"duration": "PT1H2M3S"},
+                        "statistics": {
+                            "viewCount": "12345",
+                            "likeCount": "678",
+                        },
                         "status": {
                             "license": "youtube",
                             "privacyStatus": "public",
@@ -84,6 +88,8 @@ def test_get_video_metadata_normalizes_response() -> None:
         "published_at": "2026-03-01T10:00:00Z",
         "duration": 3723,
         "duration_seconds": 3723,
+        "view_count": 12345,
+        "like_count": 678,
         "license": "standard-youtube-license",
         "privacy_status": "public",
         "embeddable": True,
@@ -95,7 +101,7 @@ def test_get_video_metadata_normalizes_response() -> None:
             "url": "https://www.googleapis.com/youtube/v3/videos",
             "params": {
                 "id": "abc123",
-                "part": "snippet,contentDetails,status",
+                "part": "snippet,contentDetails,status,statistics",
                 "key": "test-key",
             },
         }
@@ -125,6 +131,7 @@ def test_search_channel_videos_preserves_search_order() -> None:
                             },
                         },
                         "contentDetails": {"duration": "PT10M"},
+                        "statistics": {"viewCount": "200"},
                         "status": {"license": "creativeCommon"},
                     },
                     {
@@ -139,6 +146,10 @@ def test_search_channel_videos_preserves_search_order() -> None:
                             },
                         },
                         "contentDetails": {"duration": "PT4M5S"},
+                        "statistics": {
+                            "viewCount": "400",
+                            "likeCount": "25",
+                        },
                         "status": {"license": "youtube"},
                     },
                 ]
@@ -157,7 +168,11 @@ def test_search_channel_videos_preserves_search_order() -> None:
     assert [video["source_video_id"] for video in videos] == ["video-b", "video-a"]
     assert videos[0]["title"] == "Latest upload"
     assert videos[0]["duration_seconds"] == 245
+    assert videos[0]["view_count"] == 400
+    assert videos[0]["like_count"] == 25
     assert videos[1]["license"] == "creative-commons"
+    assert videos[1]["view_count"] == 200
+    assert videos[1]["like_count"] is None
     assert client.calls == [
         {
             "url": "https://www.googleapis.com/youtube/v3/search",
@@ -174,7 +189,102 @@ def test_search_channel_videos_preserves_search_order() -> None:
             "url": "https://www.googleapis.com/youtube/v3/videos",
             "params": {
                 "id": "video-b,video-a",
-                "part": "snippet,contentDetails,status",
+                "part": "snippet,contentDetails,status,statistics",
+                "key": "test-key",
+            },
+        },
+    ]
+
+
+def test_search_videos_supports_filters_and_preserves_search_order() -> None:
+    client = RecordingAsyncClient(
+        [
+            {
+                "items": [
+                    {"id": {"videoId": "video-b"}},
+                    {"id": {"videoId": "video-a"}},
+                ]
+            },
+            {
+                "items": [
+                    {
+                        "id": "video-a",
+                        "snippet": {
+                            "title": "Agent memory systems",
+                            "channelTitle": "Cerul Labs",
+                            "channelId": "channel-42",
+                            "publishedAt": "2026-02-28T10:00:00Z",
+                            "thumbnails": {
+                                "default": {"url": "https://img.youtube.com/vi/video-a/default.jpg"}
+                            },
+                        },
+                        "contentDetails": {"duration": "PT8M"},
+                        "statistics": {"viewCount": "900"},
+                        "status": {"license": "youtube"},
+                    },
+                    {
+                        "id": "video-b",
+                        "snippet": {
+                            "title": "Latest agent demo",
+                            "channelTitle": "Cerul Labs",
+                            "channelId": "channel-42",
+                            "publishedAt": "2026-03-02T10:00:00Z",
+                            "thumbnails": {
+                                "default": {"url": "https://img.youtube.com/vi/video-b/default.jpg"}
+                            },
+                        },
+                        "contentDetails": {"duration": "PT12M34S"},
+                        "statistics": {
+                            "viewCount": "1500",
+                            "likeCount": "42",
+                        },
+                        "status": {"license": "creativeCommon"},
+                    },
+                ]
+            },
+        ]
+    )
+
+    with patch("workers.common.sources.youtube.httpx.AsyncClient", return_value=client):
+        videos = asyncio.run(
+            YouTubeClient(api_key="test-key").search_videos(
+                "  agent systems  ",
+                max_results=2,
+                published_after="2026-02-01T00:00:00Z",
+                relevance_language="en",
+                video_duration="medium",
+                event_type="completed",
+            )
+        )
+
+    assert [video["source_video_id"] for video in videos] == ["video-b", "video-a"]
+    assert videos[0]["title"] == "Latest agent demo"
+    assert videos[0]["license"] == "creative-commons"
+    assert videos[0]["view_count"] == 1500
+    assert videos[0]["like_count"] == 42
+    assert videos[1]["view_count"] == 900
+    assert videos[1]["like_count"] is None
+    assert client.calls == [
+        {
+            "url": "https://www.googleapis.com/youtube/v3/search",
+            "params": {
+                "eventType": "completed",
+                "maxResults": 2,
+                "order": "relevance",
+                "part": "snippet",
+                "publishedAfter": "2026-02-01T00:00:00Z",
+                "q": "agent systems",
+                "relevanceLanguage": "en",
+                "type": "video",
+                "videoDuration": "medium",
+                "key": "test-key",
+            },
+        },
+        {
+            "url": "https://www.googleapis.com/youtube/v3/videos",
+            "params": {
+                "id": "video-b,video-a",
+                "part": "snippet,contentDetails,status,statistics",
                 "key": "test-key",
             },
         },
@@ -258,7 +368,7 @@ def test_search_channel_videos_paginates_beyond_first_50_results() -> None:
             "url": "https://www.googleapis.com/youtube/v3/videos",
             "params": {
                 "id": ",".join(first_page_ids),
-                "part": "snippet,contentDetails,status",
+                "part": "snippet,contentDetails,status,statistics",
                 "key": "test-key",
             },
         },
@@ -266,7 +376,7 @@ def test_search_channel_videos_paginates_beyond_first_50_results() -> None:
             "url": "https://www.googleapis.com/youtube/v3/videos",
             "params": {
                 "id": ",".join(second_page_ids),
-                "part": "snippet,contentDetails,status",
+                "part": "snippet,contentDetails,status,statistics",
                 "key": "test-key",
             },
         },


### PR DESCRIPTION
## Summary
- add `YouTubeClient.search_videos()` for keyword search with `published_after`, `relevance_language`, `video_duration`, and `event_type`
- include `statistics` in YouTube video detail normalization and expose `view_count` / `like_count`
- add tests for keyword search filters, response normalization, and request ordering

## Affected directories
- `workers/common/sources`
- `workers/tests`

## Env vars / config
- none

## Testing
- `pytest workers/tests/test_youtube_client.py -q` ✅
- `pytest workers/tests -q` ⚠️ fails on `workers/tests/test_knowledge_steps.py::test_heuristic_frame_analyzer_reuses_cached_frame_extractions` due `selected_frames` being empty in the cached-frame path

## Screenshots
- not applicable

## Request / response examples
- not applicable