### PR TITLE
Add retrieval unit HNSW migration

### DIFF
--- a/db/migrations/010_hnsw_index.sql
+++ b/db/migrations/010_hnsw_index.sql
@@ -1,0 +1,7 @@
+-- HNSW index for cosine similarity search on retrieval_units embeddings.
+-- CONCURRENTLY avoids long write locks, so this migration must not run
+-- inside an explicit transaction block.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_retrieval_units_embedding_hnsw
+ON retrieval_units
+USING hnsw (embedding vector_cosine_ops)
+WITH (m = 16, ef_construction = 200);

--- a/docs/tasks/search-optimization.md
+++ b/docs/tasks/search-optimization.md
@@ -24,18 +24,15 @@ These tasks can be done in parallel across separate worktrees and merged afterwa
 Create a new migration file `db/migrations/010_hnsw_index.sql`:
 
 ```sql
-BEGIN;
-
 -- HNSW index for cosine similarity search on retrieval_units embeddings.
 -- With 1K-10K vectors this provides ~5-25x speedup over brute-force scan.
 -- At 100K+ vectors the speedup is 100x+.
 -- m=16 and ef_construction=200 are good defaults for recall vs speed tradeoff.
+-- CREATE INDEX CONCURRENTLY must not run inside an explicit transaction block.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_retrieval_units_embedding_hnsw
 ON retrieval_units
 USING hnsw (embedding vector_cosine_ops)
 WITH (m = 16, ef_construction = 200);
-
-COMMIT;
 ```
 
 **How to run on Neon**:
@@ -44,7 +41,7 @@ COMMIT;
 psql "$DATABASE_URL" -f db/migrations/010_hnsw_index.sql
 ```
 
-Note: `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block in some environments. If it fails, remove the `BEGIN;`/`COMMIT;` wrapper and run the CREATE INDEX statement alone.
+Note: `CREATE INDEX CONCURRENTLY` cannot run inside an explicit transaction block, so this migration should be executed without a `BEGIN;`/`COMMIT;` wrapper.
 
 **Verification**:
 ```sql


### PR DESCRIPTION
## Summary
- add `db/migrations/010_hnsw_index.sql` to create an HNSW index on `retrieval_units.embedding` with `vector_cosine_ops`
- use `CREATE INDEX CONCURRENTLY IF NOT EXISTS` without an explicit transaction wrapper
- align the Task 1 doc so it no longer suggests wrapping the concurrent index build in `BEGIN`/`COMMIT`

## Affected directories
- `db/migrations`
- `docs/tasks`

## New env vars or configuration changes
- None

## Testing status
- Ran `git diff --check`
- Could not run `psql "$DATABASE_URL" -f db/migrations/010_hnsw_index.sql` because `DATABASE_URL` is not configured in this workspace/session

## Screenshots
- N/A

## Request/response examples
- N/A