### PR TITLE
Merge unified search unit queries

### DIFF
--- a/backend/app/search/unified.py
+++ b/backend/app/search/unified.py
@@ -73,7 +73,8 @@ class UnifiedSearchService:
         if request.include_summary:
             allowed_unit_types.insert(0, "summary")
 
-        candidate_limit = min(max(request.max_results * 8, 24), 120)
+        candidate_limit_per_type = min(max(request.max_results * 8, 24), 120)
+        candidate_limit = candidate_limit_per_type * len(allowed_unit_types)
         candidate_rows = await self._fetch_unit_rows(
             filters=request.filters,
             query_vector=resolved_query_vector,

--- a/backend/app/search/unified.py
+++ b/backend/app/search/unified.py
@@ -74,16 +74,14 @@ class UnifiedSearchService:
             allowed_unit_types.insert(0, "summary")
 
         candidate_limit = min(max(request.max_results * 8, 24), 120)
-        candidate_rows: list[dict[str, Any]] = []
-        for unit_type in allowed_unit_types:
-            rows = await self._fetch_unit_rows(
-                filters=request.filters,
-                query_vector=resolved_query_vector,
-                unit_type=unit_type,
-                user_id=user_id,
-                limit=candidate_limit,
-            )
-            candidate_rows.extend(rows)
+        candidate_rows = await self._fetch_unit_rows(
+            filters=request.filters,
+            query_vector=resolved_query_vector,
+            unit_type=None,
+            user_id=user_id,
+            limit=candidate_limit,
+            allowed_unit_types=allowed_unit_types,
+        )
 
         candidate_rows = self._dedupe_rows(candidate_rows)
         if not candidate_rows:
@@ -179,25 +177,35 @@ class UnifiedSearchService:
         *,
         filters: UnifiedFilters | None,
         query_vector: Sequence[float],
-        unit_type: str,
+        unit_type: str | None,
         user_id: str,
         limit: int,
+        allowed_unit_types: Sequence[str] | None = None,
     ) -> list[dict[str, Any]]:
-        params: list[Any] = [
-            vector_to_literal(query_vector),
-            unit_type,
-            user_id,
-        ]
-        conditions = [
-            "ru.unit_type = $2",
-            (
-                "EXISTS ("
-                "SELECT 1 FROM video_access AS va "
-                "WHERE va.video_id = ru.video_id "
-                "AND (va.owner_id IS NULL OR va.owner_id = $3)"
-                ")"
-            ),
-        ]
+        params: list[Any] = [vector_to_literal(query_vector)]
+        conditions: list[str] = []
+
+        if allowed_unit_types is not None:
+            normalized_unit_types = [value for value in allowed_unit_types if value]
+            if not normalized_unit_types:
+                raise ValueError("allowed_unit_types must contain at least one value")
+            params.append(normalized_unit_types)
+            conditions.append(f"ru.unit_type = ANY(${len(params)}::text[])")
+        elif unit_type is not None:
+            params.append(unit_type)
+            conditions.append(f"ru.unit_type = ${len(params)}")
+        else:
+            raise ValueError("unit_type or allowed_unit_types must be provided")
+
+        params.append(user_id)
+        user_id_param = len(params)
+        conditions.append(
+            "EXISTS ("
+            "SELECT 1 FROM video_access AS va "
+            "WHERE va.video_id = ru.video_id "
+            f"AND (va.owner_id IS NULL OR va.owner_id = ${user_id_param})"
+            ")"
+        )
 
         if filters is not None and filters.speaker is not None:
             params.append(filters.speaker)

--- a/backend/tests/test_search_services.py
+++ b/backend/tests/test_search_services.py
@@ -310,6 +310,7 @@ def test_unified_search_embeds_query_text_and_returns_tracking_url(
     assert "ru.unit_type = ANY($2::text[])" in database.fetch_calls[0][0]
     assert database.fetch_calls[0][1][0] == vector_to_literal(query_vector)
     assert database.fetch_calls[0][1][1] == ["speech", "visual"]
+    assert database.fetch_calls[0][1][-1] == 48
     assert "Resolved unified query vector with 3072 dimensions via fake-gemini" in caplog.text
 
 
@@ -515,6 +516,7 @@ def test_unified_search_can_include_summary_results_when_requested() -> None:
     assert len(database.fetch_calls) == 1
     assert "ru.unit_type = ANY($2::text[])" in database.fetch_calls[0][0]
     assert database.fetch_calls[0][1][1] == ["summary", "speech", "visual"]
+    assert database.fetch_calls[0][1][-1] == 72
 
 
 def test_unified_search_visual_snippet_prefers_scene_description_over_ocr() -> None:

--- a/backend/tests/test_search_services.py
+++ b/backend/tests/test_search_services.py
@@ -65,7 +65,13 @@ class FakeDatabase:
 
     async def fetch(self, sql: str, *params: object) -> list[dict[str, object]]:
         self.fetch_calls.append((sql, params))
-        unit_type = str(params[1])
+        requested_types = params[1]
+        if isinstance(requested_types, (list, tuple)):
+            rows: list[dict[str, object]] = []
+            for unit_type in requested_types:
+                rows.extend(self.rows_by_unit_type.get(str(unit_type), []))
+            return rows
+        unit_type = str(requested_types)
         return self.rows_by_unit_type.get(unit_type, [])
 
 
@@ -300,7 +306,10 @@ def test_unified_search_embeds_query_text_and_returns_tracking_url(
     assert execution.results[0].url.path.startswith("/v/")
     assert execution.results[0].unit_type == "speech"
     assert embedding_backend.calls == ["agent workflows"]
+    assert len(database.fetch_calls) == 1
+    assert "ru.unit_type = ANY($2::text[])" in database.fetch_calls[0][0]
     assert database.fetch_calls[0][1][0] == vector_to_literal(query_vector)
+    assert database.fetch_calls[0][1][1] == ["speech", "visual"]
     assert "Resolved unified query vector with 3072 dimensions via fake-gemini" in caplog.text
 
 
@@ -503,6 +512,9 @@ def test_unified_search_can_include_summary_results_when_requested() -> None:
 
     assert [result.id for result in execution.results] == ["summary_1"]
     assert execution.results[0].timestamp_start is None
+    assert len(database.fetch_calls) == 1
+    assert "ru.unit_type = ANY($2::text[])" in database.fetch_calls[0][0]
+    assert database.fetch_calls[0][1][1] == ["summary", "speech", "visual"]
 
 
 def test_unified_search_visual_snippet_prefers_scene_description_over_ocr() -> None:


### PR DESCRIPTION
## Summary
- merge unified search candidate retrieval into a single pgvector query using `ANY($2::text[])`
- keep `_fetch_unit_rows` backward compatible for single `unit_type` callers while making the user access predicate parameter indexing dynamic
- update unified search service tests to cover the new single-query path and summary-inclusive query list

## Affected Directories
- `backend/app/search`
- `backend/tests`

## Env Vars / Config Changes
- none

## Testing
- `python3 -m pytest backend/tests -q`

## Screenshots
- none

## API Examples
- no request/response shape changes; this PR only reduces DB round trips for unified search candidate retrieval