### PR TITLE
Deduplicate unified search segments

### DIFF
--- a/backend/app/routers/tracking.py
+++ b/backend/app/routers/tracking.py
@@ -92,11 +92,7 @@ async def _record_tracking_event(
 
 
 def _build_snippet(tracking_row: dict[str, Any]) -> str:
-    unit_type = str(tracking_row.get("unit_type") or "")
-    if unit_type == "visual":
-        value = tracking_row.get("visual_desc")
-    else:
-        value = tracking_row.get("transcript") or tracking_row.get("visual_desc")
+    value = tracking_row.get("transcript") or tracking_row.get("visual_desc")
     text = str(value or "").strip()
     if len(text) <= 240:
         return text

--- a/backend/app/search/unified.py
+++ b/backend/app/search/unified.py
@@ -144,8 +144,11 @@ class UnifiedSearchService:
                     "unit_type": str(row.get("unit_type") or "speech"),
                     "timestamp_start": self._coerce_optional_float(row.get("timestamp_start")),
                     "timestamp_end": self._coerce_optional_float(row.get("timestamp_end")),
-                    "transcript": row.get("transcript"),
-                    "visual_desc": row.get("visual_desc"),
+                    "transcript": row.get("transcript_text"),
+                    "visual_desc": (
+                        row.get("visual_description")
+                        or row.get("visual_summary")
+                    ),
                     "keyframe_url": row.get("keyframe_url"),
                 }
             )
@@ -278,15 +281,55 @@ class UnifiedSearchService:
         )
 
     def _dedupe_rows(self, rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
-        deduped: list[dict[str, Any]] = []
-        seen_ids: set[str] = set()
+        by_id: dict[str, dict[str, Any]] = {}
         for row in rows:
             row_id = str(row.get("id") or "")
-            if not row_id or row_id in seen_ids:
+            if not row_id or row_id in by_id:
                 continue
-            seen_ids.add(row_id)
-            deduped.append(row)
-        return deduped
+            by_id[row_id] = dict(row)
+
+        segment_key_map: dict[str, dict[str, Any]] = {}
+        for row in by_id.values():
+            video_id = str(row.get("video_id") or "")
+            timestamp_start = row.get("timestamp_start")
+            timestamp_end = row.get("timestamp_end")
+            if video_id and timestamp_start is not None and timestamp_end is not None:
+                segment_key = (
+                    f"{video_id}:{float(timestamp_start):.2f}-{float(timestamp_end):.2f}"
+                )
+            else:
+                segment_key = str(row.get("id") or "")
+
+            existing = segment_key_map.get(segment_key)
+            if existing is None:
+                segment_key_map[segment_key] = row
+                continue
+
+            existing_score = float(existing.get("score", 0.0) or 0.0)
+            new_score = float(row.get("score", 0.0) or 0.0)
+            if new_score > existing_score:
+                merged = dict(row)
+                self._merge_segment_fields(merged, existing)
+                segment_key_map[segment_key] = merged
+                continue
+
+            self._merge_segment_fields(existing, row)
+
+        return list(segment_key_map.values())
+
+    def _merge_segment_fields(
+        self,
+        target: dict[str, Any],
+        source: dict[str, Any],
+    ) -> None:
+        if not target.get("transcript_text") and source.get("transcript_text"):
+            target["transcript_text"] = source["transcript_text"]
+        if not target.get("visual_description") and source.get("visual_description"):
+            target["visual_description"] = source["visual_description"]
+        if not target.get("visual_summary") and source.get("visual_summary"):
+            target["visual_summary"] = source["visual_summary"]
+        if not target.get("visual_text_content") and source.get("visual_text_content"):
+            target["visual_text_content"] = source["visual_text_content"]
 
     def _cap_per_video(
         self,
@@ -329,18 +372,15 @@ class UnifiedSearchService:
         return target_url
 
     def _build_snippet(self, row: dict[str, Any]) -> str:
-        unit_type = str(row.get("unit_type") or "speech")
-        if unit_type == "visual":
+        value = row.get("transcript_text")
+        if not value:
             value = (
                 row.get("visual_description")
                 or row.get("visual_summary")
                 or row.get("visual_text_content")
                 or row.get("content_text")
+                or row.get("description")
             )
-        elif unit_type == "summary":
-            value = row.get("content_text") or row.get("description")
-        else:
-            value = row.get("transcript_text") or row.get("content_text") or row.get("description")
         return self._truncate_text(str(value or "").strip(), limit=220)
 
     def _coerce_optional_float(self, value: Any) -> float | None:

--- a/backend/tests/test_search_services.py
+++ b/backend/tests/test_search_services.py
@@ -319,6 +319,7 @@ def test_unified_search_embeds_image_only_query(tmp_path: Path) -> None:
                     unit_type="visual",
                     score=0.91,
                     embedding=query_vector,
+                    transcript_text="",
                     visual_summary="A man and a woman sit in a room with a fireplace.",
                 )
             ]
@@ -368,6 +369,7 @@ def test_unified_search_embeds_text_and_image_query(tmp_path: Path) -> None:
                     unit_type="visual",
                     score=0.91,
                     embedding=query_vector,
+                    transcript_text="",
                     visual_summary="A man and a woman sit in a room with a fireplace.",
                 )
             ]
@@ -505,6 +507,50 @@ def test_unified_search_can_include_summary_results_when_requested() -> None:
     assert execution.results[0].timestamp_start is None
 
 
+def test_dedupe_rows_merges_same_segment_results_across_unit_types() -> None:
+    query_vector = build_placeholder_vector(
+        "rocket launch",
+        DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+    )
+    service = UnifiedSearchService(
+        FakeDatabase({}),
+        embedding_backend=FakeEmbeddingBackend(query_vector),
+        reranker=StaticReranker(),
+    )
+
+    deduped = service._dedupe_rows(
+        [
+            build_unified_row(
+                row_id="speech_1",
+                unit_type="speech",
+                score=0.84,
+                embedding=query_vector,
+                transcript_text="The rocket clears the tower as the countdown hits zero.",
+                visual_summary="",
+            ),
+            build_unified_row(
+                row_id="visual_1",
+                unit_type="visual",
+                score=0.93,
+                embedding=query_vector,
+                transcript_text="",
+                visual_summary="A rocket lifts off in a bright plume of smoke and flame.",
+            ),
+        ]
+    )
+
+    assert len(deduped) == 1
+    assert deduped[0]["id"] == "visual_1"
+    assert deduped[0]["unit_type"] == "visual"
+    assert deduped[0]["score"] == pytest.approx(0.93)
+    assert deduped[0]["transcript_text"] == (
+        "The rocket clears the tower as the countdown hits zero."
+    )
+    assert deduped[0]["visual_description"] == (
+        "A rocket lifts off in a bright plume of smoke and flame."
+    )
+
+
 def test_unified_search_visual_snippet_prefers_scene_description_over_ocr() -> None:
     query_vector = build_placeholder_vector(
         "fireplace interview",
@@ -518,6 +564,7 @@ def test_unified_search_visual_snippet_prefers_scene_description_over_ocr() -> N
                     unit_type="visual",
                     score=0.91,
                     embedding=query_vector,
+                    transcript_text="",
                     visual_summary="A man and a woman sit in a room with a fireplace.",
                 )
             ]
@@ -546,6 +593,61 @@ def test_unified_search_visual_snippet_prefers_scene_description_over_ocr() -> N
     assert execution.results[0].snippet == "A man and a woman sit in a room with a fireplace."
 
 
+def test_unified_search_merged_segment_snippet_prefers_transcript() -> None:
+    query_vector = build_placeholder_vector(
+        "rocket launch",
+        DEFAULT_KNOWLEDGE_VECTOR_DIMENSION,
+    )
+    database = FakeDatabase(
+        {
+            "speech": [
+                build_unified_row(
+                    row_id="speech_1",
+                    unit_type="speech",
+                    score=0.84,
+                    embedding=query_vector,
+                    transcript_text="The rocket clears the tower as the countdown hits zero.",
+                    visual_summary="",
+                )
+            ],
+            "visual": [
+                build_unified_row(
+                    row_id="visual_1",
+                    unit_type="visual",
+                    score=0.93,
+                    embedding=query_vector,
+                    transcript_text="",
+                    visual_summary="A rocket lifts off in a bright plume of smoke and flame.",
+                )
+            ],
+        }
+    )
+    service = UnifiedSearchService(
+        database,
+        embedding_backend=FakeEmbeddingBackend(query_vector),
+        reranker=StaticReranker(),
+    )
+
+    execution = asyncio.run(
+        service.search(
+            SearchRequest.model_validate(
+                {
+                    "query": "rocket launch",
+                    "max_results": 5,
+                }
+            ),
+            user_id="user_stub",
+            request_id="req_123",
+        )
+    )
+
+    assert [result.id for result in execution.results] == ["visual_1"]
+    assert execution.results[0].unit_type == "visual"
+    assert execution.results[0].snippet == (
+        "The rocket clears the tower as the countdown hits zero."
+    )
+
+
 def test_unified_search_rerank_mode_keeps_embedding_score_and_exposes_rerank_score() -> None:
     query_vector = build_placeholder_vector(
         "agent workflows",
@@ -559,12 +661,16 @@ def test_unified_search_rerank_mode_keeps_embedding_score_and_exposes_rerank_sco
                     unit_type="speech",
                     score=0.72,
                     embedding=query_vector,
+                    timestamp_start=120.0,
+                    timestamp_end=178.5,
                 ),
                 build_unified_row(
                     row_id="segment_2",
                     unit_type="speech",
                     score=0.61,
                     embedding=query_vector,
+                    timestamp_start=180.0,
+                    timestamp_end=238.5,
                 ),
             ]
         }

--- a/backend/tests/test_tracking_api.py
+++ b/backend/tests/test_tracking_api.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
+import app.routers.tracking as tracking_router
 from conftest import (
     TEST_KNOWLEDGE_VIDEO_ID,
     TEST_UNIFIED_KNOWLEDGE_UNIT_ID,
@@ -105,6 +106,18 @@ def test_tracking_not_found_returns_branded_404() -> None:
 
     assert response.status_code == 404
     assert "Cerul tracking link not found." in response.text
+
+
+def test_tracking_snippet_prefers_transcript_for_merged_visual_results() -> None:
+    snippet = tracking_router._build_snippet(
+        {
+            "unit_type": "visual",
+            "transcript": "The rocket clears the tower as the countdown hits zero.",
+            "visual_desc": "A rocket lifts off in a bright plume of smoke and flame.",
+        }
+    )
+
+    assert snippet == "The rocket clears the tower as the countdown hits zero."
 
 
 def test_tracking_links_keep_working_after_video_and_unit_are_removed(database) -> None:


### PR DESCRIPTION
## Summary
- deduplicate unified search rows by video segment instead of only retrieval unit id
- preserve transcript and visual fields when merging speech and visual hits, and prefer transcript snippets when present
- align tracking payload/detail snippets with merged search results and add coverage for the new behavior

## Affected Directories
- backend/app/search
- backend/app/routers
- backend/tests

## Env / Config Changes
- None

## Testing
- `python3 -m pytest backend/tests/test_search_services.py backend/tests/test_search_api.py backend/tests/test_tracking_api.py -q`

## Screenshots
- None

## API Examples
- Not changed in shape for this task; search results now return one item per merged segment when speech and visual hits share the same timestamp range.