### PR TITLE
Remove public unit_type from unified search results

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'db/migrations/**'
+      - 'scripts/migrate-db.sh'
+      - '.github/workflows/migration-check.yml'
 
 jobs:
   validate-sql:
@@ -30,18 +32,9 @@ jobs:
 
       - name: Run migrations against test database
         env:
-          PGHOST: localhost
-          PGPORT: 5432
-          PGUSER: cerul_test
-          PGPASSWORD: cerul_test
-          PGDATABASE: cerul_test
+          DATABASE_URL: postgresql://cerul_test:cerul_test@localhost:5432/cerul_test
         run: |
-          echo "Running all migration files in order..."
-          find db/migrations -type f -name '*.sql' | sort | while IFS= read -r f; do
-            echo "==> Applying $f"
-            psql -v ON_ERROR_STOP=1 -f "$f"
-            echo "    OK"
-          done
+          ./scripts/migrate-db.sh
 
       - name: Verify schema tables exist
         env:

--- a/backend/app/search/models.py
+++ b/backend/app/search/models.py
@@ -94,7 +94,6 @@ class SearchResult(StrictModel):
     speaker: str | None = None
     timestamp_start: float | None = Field(default=None, ge=0.0)
     timestamp_end: float | None = Field(default=None, ge=0.0)
-    unit_type: Literal["summary", "speech", "visual"]
 
     @model_validator(mode="after")
     def validate_timestamps(self) -> "SearchResult":

--- a/backend/app/search/unified.py
+++ b/backend/app/search/unified.py
@@ -166,7 +166,6 @@ class UnifiedSearchService:
                     speaker=row.get("speaker"),
                     timestamp_start=self._coerce_optional_float(row.get("timestamp_start")),
                     timestamp_end=self._coerce_optional_float(row.get("timestamp_end")),
-                    unit_type=str(row.get("unit_type") or "speech"),  # type: ignore[arg-type]
                 )
             )
 
@@ -232,6 +231,11 @@ class UnifiedSearchService:
             conditions.append(f"v.source = ${len(params)}")
 
         params.append(limit)
+        distance_sql = (
+            f"(ru.embedding::halfvec({DEFAULT_KNOWLEDGE_VECTOR_DIMENSION}) <=> "
+            f"($1::vector({DEFAULT_KNOWLEDGE_VECTOR_DIMENSION}))"
+            f"::halfvec({DEFAULT_KNOWLEDGE_VECTOR_DIMENSION}))"
+        )
         sql = f"""
             SELECT
                 ru.id::text AS id,
@@ -249,7 +253,7 @@ class UnifiedSearchService:
                 ru.timestamp_start,
                 ru.timestamp_end,
                 ru.embedding::text AS embedding,
-                1 - (ru.embedding <=> $1::vector) AS score,
+                1 - {distance_sql} AS score,
                 v.title,
                 v.description,
                 v.source,
@@ -265,7 +269,7 @@ class UnifiedSearchService:
             JOIN videos AS v
                 ON v.id = ru.video_id
             WHERE {' AND '.join(conditions)}
-            ORDER BY ru.embedding <=> $1::vector
+            ORDER BY {distance_sql}
             LIMIT ${len(params)}
         """
         return [dict(row) for row in await self.db.fetch(sql, *params)]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -186,6 +186,34 @@ def _run_migration(database_url: str, migration_file: Path) -> None:
         )
 
 
+async def _should_skip_migration(database_url: str, migration_name: str) -> bool:
+    if migration_name != "010_hnsw_index.sql":
+        return False
+
+    connection = await asyncpg.connect(database_url)
+    try:
+        embedding_type = await connection.fetchval(
+            """
+            SELECT format_type(a.atttypid, a.atttypmod)
+            FROM pg_attribute AS a
+            JOIN pg_class AS c
+                ON c.oid = a.attrelid
+            JOIN pg_namespace AS n
+                ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public'
+              AND c.relname = 'retrieval_units'
+              AND a.attname = 'embedding'
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+            """
+        )
+    finally:
+        await connection.close()
+
+    # Migration 011 replaces the incompatible 3072-dim HNSW definition.
+    return embedding_type == "vector(3072)"
+
+
 async def _ensure_schema(database_url: str) -> None:
     migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
     if not migration_files:
@@ -205,9 +233,13 @@ async def _ensure_schema(database_url: str) -> None:
         for migration_file in migration_files:
             if migration_file.name.startswith("001_"):
                 continue
+            if await _should_skip_migration(database_url, migration_file.name):
+                continue
             _run_migration(database_url, migration_file)
     else:
         for migration_file in migration_files:
+            if await _should_skip_migration(database_url, migration_file.name):
+                continue
             _run_migration(database_url, migration_file)
 
 

--- a/backend/tests/test_search_api.py
+++ b/backend/tests/test_search_api.py
@@ -90,10 +90,11 @@ def test_search_endpoint_records_usage_query_logs_and_tracking_links(database) -
     assert payload["credits_remaining"] == 999
     assert re.fullmatch(r"req_[a-f0-9]{24}", payload["request_id"])
     assert payload["results"][0]["id"] == TEST_UNIFIED_BROLL_UNIT_ID
-    assert payload["results"][0]["unit_type"] == "visual"
+    assert "unit_type" not in payload["results"][0]
     assert payload["results"][0]["url"].startswith(("http://localhost:3000/v/", "http://127.0.0.1:3000/v/"))
     assert database.fetchval("SELECT COUNT(*) FROM query_logs") == 1
     assert database.fetchval("SELECT COUNT(*) FROM tracking_links") == 1
+    assert database.fetchval("SELECT unit_type FROM tracking_links LIMIT 1") == "visual"
     latency_ms = database.fetchval(
         "SELECT latency_ms FROM query_logs WHERE request_id = $1",
         payload["request_id"],

--- a/backend/tests/test_search_services.py
+++ b/backend/tests/test_search_services.py
@@ -304,7 +304,8 @@ def test_unified_search_embeds_query_text_and_returns_tracking_url(
     assert len(execution.results) == 1
     assert execution.results[0].id == "segment_1"
     assert execution.results[0].url.path.startswith("/v/")
-    assert execution.results[0].unit_type == "speech"
+    assert "unit_type" not in execution.results[0].model_dump()
+    assert execution.tracking_links[0]["unit_type"] == "speech"
     assert embedding_backend.calls == ["agent workflows"]
     assert len(database.fetch_calls) == 1
     assert "ru.unit_type = ANY($2::text[])" in database.fetch_calls[0][0]
@@ -359,7 +360,8 @@ def test_unified_search_embeds_image_only_query(tmp_path: Path) -> None:
     )
 
     assert len(execution.results) == 1
-    assert execution.results[0].unit_type == "visual"
+    assert "unit_type" not in execution.results[0].model_dump()
+    assert execution.tracking_links[0]["unit_type"] == "visual"
     assert embedding_backend.calls == []
     assert embedding_backend.multimodal_calls == [(None, str(image_path))]
 
@@ -410,7 +412,8 @@ def test_unified_search_embeds_text_and_image_query(tmp_path: Path) -> None:
     )
 
     assert len(execution.results) == 1
-    assert execution.results[0].unit_type == "visual"
+    assert "unit_type" not in execution.results[0].model_dump()
+    assert execution.tracking_links[0]["unit_type"] == "visual"
     assert embedding_backend.calls == []
     assert embedding_backend.multimodal_calls == [("fireplace interview", str(image_path))]
 
@@ -603,7 +606,7 @@ def test_unified_search_visual_snippet_prefers_scene_description_over_ocr() -> N
         )
     )
 
-    assert execution.results[0].unit_type == "visual"
+    assert "unit_type" not in execution.results[0].model_dump()
     assert execution.results[0].snippet == "A man and a woman sit in a room with a fireplace."
 
 
@@ -656,7 +659,7 @@ def test_unified_search_merged_segment_snippet_prefers_transcript() -> None:
     )
 
     assert [result.id for result in execution.results] == ["visual_1"]
-    assert execution.results[0].unit_type == "visual"
+    assert "unit_type" not in execution.results[0].model_dump()
     assert execution.results[0].snippet == (
         "The rocket clears the tower as the countdown hits zero."
     )

--- a/db/migrations/010_hnsw_index.sql
+++ b/db/migrations/010_hnsw_index.sql
@@ -1,13 +1,7 @@
 -- HNSW index for cosine similarity search on retrieval_units embeddings.
--- retrieval_units stores 3072-dim vectors, so cast to halfvec to stay within
--- pgvector's HNSW dimension limit while preserving ANN search support.
--- DROP INDEX CONCURRENTLY cleans up invalid leftovers from previously failed
--- concurrent index builds before recreating the index with the same name.
 -- CONCURRENTLY avoids long write locks, so this migration must not run
 -- inside an explicit transaction block.
-DROP INDEX CONCURRENTLY IF EXISTS idx_retrieval_units_embedding_hnsw;
-
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_retrieval_units_embedding_hnsw
 ON retrieval_units
-USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)
+USING hnsw (embedding vector_cosine_ops)
 WITH (m = 16, ef_construction = 200);

--- a/db/migrations/010_hnsw_index.sql
+++ b/db/migrations/010_hnsw_index.sql
@@ -1,7 +1,13 @@
 -- HNSW index for cosine similarity search on retrieval_units embeddings.
+-- retrieval_units stores 3072-dim vectors, so cast to halfvec to stay within
+-- pgvector's HNSW dimension limit while preserving ANN search support.
+-- DROP INDEX CONCURRENTLY cleans up invalid leftovers from previously failed
+-- concurrent index builds before recreating the index with the same name.
 -- CONCURRENTLY avoids long write locks, so this migration must not run
 -- inside an explicit transaction block.
+DROP INDEX CONCURRENTLY IF EXISTS idx_retrieval_units_embedding_hnsw;
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_retrieval_units_embedding_hnsw
 ON retrieval_units
-USING hnsw (embedding vector_cosine_ops)
+USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)
 WITH (m = 16, ef_construction = 200);

--- a/db/migrations/011_rebuild_retrieval_units_hnsw_index.sql
+++ b/db/migrations/011_rebuild_retrieval_units_hnsw_index.sql
@@ -1,0 +1,11 @@
+-- Rebuild the retrieval_units HNSW index using halfvec so 3072-dim
+-- embeddings remain indexable under pgvector's HNSW dimension limit.
+-- DROP INDEX CONCURRENTLY cleans up invalid leftovers from previously failed
+-- concurrent index builds before recreating the index with the same name.
+-- This migration must stay outside an explicit transaction block.
+DROP INDEX CONCURRENTLY IF EXISTS idx_retrieval_units_embedding_hnsw;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_retrieval_units_embedding_hnsw
+ON retrieval_units
+USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)
+WITH (m = 16, ef_construction = 200);

--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -218,6 +218,9 @@ migration_matches_schema() {
     004_admin_console.sql)
       result="$(psql_query "SELECT CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'user_profiles' AND column_name = 'console_role') AND to_regclass('public.admin_metric_targets') IS NOT NULL THEN 'true' ELSE 'false' END")"
       ;;
+    010_hnsw_index.sql)
+      result="$(psql_query "SELECT CASE WHEN (SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a JOIN pg_class c ON c.oid = a.attrelid JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'retrieval_units' AND a.attname = 'embedding' AND a.attnum > 0 AND NOT a.attisdropped) = 'vector(3072)' THEN 'true' ELSE 'false' END")"
+      ;;
     *)
       result="false"
       ;;

--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -219,7 +219,18 @@ migration_matches_schema() {
       result="$(psql_query "SELECT CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'user_profiles' AND column_name = 'console_role') AND to_regclass('public.admin_metric_targets') IS NOT NULL THEN 'true' ELSE 'false' END")"
       ;;
     010_hnsw_index.sql)
-      result="$(psql_query "SELECT CASE WHEN (SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a JOIN pg_class c ON c.oid = a.attrelid JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'retrieval_units' AND a.attname = 'embedding' AND a.attnum > 0 AND NOT a.attisdropped) = 'vector(3072)' THEN 'true' ELSE 'false' END")"
+      local retrieval_units_embedding_type
+      retrieval_units_embedding_type="$(psql_query "SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a JOIN pg_class c ON c.oid = a.attrelid JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'retrieval_units' AND a.attname = 'embedding' AND a.attnum > 0 AND NOT a.attisdropped")"
+
+      if [[ "${retrieval_units_embedding_type}" == "vector(3072)" ]]; then
+        if should_include_migration "011_rebuild_retrieval_units_hnsw_index.sql"; then
+          result="true"
+        else
+          result="$(psql_query "SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'retrieval_units' AND indexname = 'idx_retrieval_units_embedding_hnsw' AND indexdef LIKE '%halfvec_cosine_ops%') THEN 'true' ELSE 'false' END")"
+        fi
+      else
+        result="false"
+      fi
       ;;
     *)
       result="false"


### PR DESCRIPTION
## Summary
- remove `unit_type` from the public unified search response model and result serialization
- keep `unit_type` in internal tracking link payloads and update search tests to assert the new public contract
- fix the retrieval unit HNSW migration to rebuild an invalid leftover index and use a `halfvec(3072)` expression compatible with pgvector limits

## Affected Directories
- `backend/app/search`
- `backend/tests`
- `db/migrations`

## Configuration Changes
- No new environment variables
- No config file changes

## Testing Status
- `python3 -m pytest backend/tests -q`

## Screenshots
- N/A

## API Example
Request:
```json
{
  "query": "rocket launch",
  "max_results": 1
}
```

Response excerpt:
```json
{
  "results": [
    {
      "id": "00000000-0000-0000-0000-000000000031",
      "score": 0.91,
      "url": "http://localhost:3000/v/abcd1234",
      "title": "OpenAI Dev Day Keynote",
      "snippet": "The rocket clears the tower as the countdown hits zero.",
      "thumbnail_url": "https://example.com/keynote.jpg",
      "keyframe_url": "https://example.com/keyframe.jpg",
      "duration": 3600,
      "source": "youtube",
      "speaker": "Sam Altman",
      "timestamp_start": 120.0,
      "timestamp_end": 178.5
    }
  ]
}
```
