### PR TITLE
Fix yt-dlp: skip android client when cookies present

### DIFF
--- a/workers/knowledge/runtime.py
+++ b/workers/knowledge/runtime.py
@@ -582,7 +582,7 @@ class YtDlpCaptionProvider:
         output_template = output_dir / f"{source_video_id}.%(ext)s"
         command = [
             self._command,
-            "--extractor-args", "youtube:player_client=android",
+            *(["--extractor-args", "youtube:player_client=android"] if self._cookies_file is None else []),
             "--skip-download",
             "--write-subs",
             "--write-auto-subs",
@@ -738,7 +738,7 @@ class YtDlpVideoDownloader:
         command = [
             self._command,
             "--no-playlist",
-            "--extractor-args", "youtube:player_client=android",
+            *(["--extractor-args", "youtube:player_client=android"] if self._cookies_file is None else []),
             "--format",
             format_selector,
             "--output",


### PR DESCRIPTION
## Summary

yt-dlp's android player client does not support cookies. When cookies are configured (e.g., on Hetzner VPS), all downloads fail with "Skipping client android since it does not support cookies". 

Now only uses `--extractor-args youtube:player_client=android` when no cookies file is present.

## Test plan

- [x] `pytest workers/tests/test_knowledge_steps.py` — 55 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)