### PR TITLE
Add unzip to Dockerfile for Deno

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ffmpeg \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fL "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/yt-dlp" \


### PR DESCRIPTION
Deno installer requires unzip. 🤖 Generated with [Claude Code](https://claude.com/claude-code)