### PR TITLE
Reuse single DB connection per request

### DIFF
--- a/api/src/db/client.ts
+++ b/api/src/db/client.ts
@@ -138,3 +138,43 @@ class NeonDatabaseClient implements DatabaseClient {
 export function createDatabaseClient(env: Bindings): DatabaseClient {
   return new NeonDatabaseClient(env);
 }
+
+/**
+ * Create a DatabaseClient backed by a single pooled connection.
+ * The connection is acquired lazily on first query and reused for
+ * all subsequent queries within the same request. Call `dispose()`
+ * at the end of the request to release the connection back to the pool.
+ */
+export function createPooledDatabaseClient(env: Bindings): DatabaseClient & { dispose(): Promise<void> } {
+  const pool = new Pool({
+    connectionString: requireDatabaseUrl(env),
+    max: 1
+  });
+  let client: Queryable | null = null;
+
+  const inner = {
+    async getClient(): Promise<Queryable> {
+      if (!client) {
+        client = (await pool.connect()) as Queryable;
+      }
+      return client;
+    }
+  };
+
+  const db = new NeonDatabaseClient(env, {
+    async query(queryText: string, params?: QueryValue[]) {
+      const c = await inner.getClient();
+      return c.query(queryText, params);
+    }
+  } as Queryable);
+
+  return Object.assign(db, {
+    async dispose() {
+      if (client) {
+        client.release?.();
+        client = null;
+      }
+      await pool.end();
+    }
+  });
+}

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import type { Context, MiddlewareHandler } from "hono";
 
 import { getConfig } from "../config";
 import type { AuthContext, Bindings, SessionContext } from "../types";
-import { createDatabaseClient } from "../db/client";
+import { createDatabaseClient, createPooledDatabaseClient } from "../db/client";
 import type { DatabaseClient } from "../db/client";
 import { calculateCreditsRemaining, fetchUsageSummary } from "../services/billing";
 import { hmacSha256Hex, sha256Hex, timingSafeEqual } from "../utils/crypto";
@@ -51,8 +51,13 @@ function getDb(c: Context): DatabaseClient {
 export function baseContextMiddleware(): MiddlewareHandler {
   return async (c: any, next: () => Promise<void>) => {
     c.set("config", getConfig(c.env));
-    c.set("db", createDatabaseClient(c.env));
-    await next();
+    const db = createPooledDatabaseClient(c.env);
+    c.set("db", db);
+    try {
+      await next();
+    } finally {
+      await db.dispose();
+    }
   };
 }
 


### PR DESCRIPTION
## Summary
- Every query was creating a new Pool + connection (8-15 per request)
- Now one connection is lazily acquired and reused for the entire request
- Released in finally block of baseContextMiddleware

## Impact
Reduces connection overhead for all API endpoints, especially MCP which has the longest query chain.

## Test plan
- [ ] `/v1/search` still works
- [ ] `/v1/usage` still works  
- [ ] `/mcp` tool calls work
- [ ] Connection is released even on errors