### PR TITLE
Support path-based tracking URLs in frontend proxy

### DIFF
--- a/frontend/app/v/[shortId]/[[...path]]/route.test.ts
+++ b/frontend/app/v/[shortId]/[[...path]]/route.test.ts
@@ -93,6 +93,56 @@ describe("tracking proxy route", () => {
     expect(String(target)).toBe("http://127.0.0.1:8787/v/abc123xy/detail");
   });
 
+  it("forwards path-based tracking URLs to the backend", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://www.youtube.com/watch?v=demo123&t=42",
+          },
+        }),
+      ),
+    );
+
+    const request = new NextRequest("http://127.0.0.1:3001/v/abc123xy/req_deadbeef/2");
+    const response = await GET(request, {
+      params: Promise.resolve({
+        shortId: "abc123xy",
+        path: ["req_deadbeef", "2"],
+      }),
+    });
+
+    expect(response.status).toBe(302);
+    const [target] = vi.mocked(global.fetch).mock.calls[0] ?? [];
+    expect(String(target)).toBe("http://127.0.0.1:8787/v/abc123xy/req_deadbeef/2");
+  });
+
+  it("forwards path-based tracking URLs with detail suffix", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("<html>detail</html>", {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      ),
+    );
+
+    const request = new NextRequest("http://127.0.0.1:3001/v/abc123xy/req_deadbeef/2/detail");
+    const response = await GET(request, {
+      params: Promise.resolve({
+        shortId: "abc123xy",
+        path: ["req_deadbeef", "2", "detail"],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const [target] = vi.mocked(global.fetch).mock.calls[0] ?? [];
+    expect(String(target)).toBe("http://127.0.0.1:8787/v/abc123xy/req_deadbeef/2/detail");
+  });
+
   it("rejects unsupported tracking suffixes", async () => {
     vi.stubGlobal("fetch", vi.fn());
 

--- a/frontend/app/v/[shortId]/[[...path]]/route.ts
+++ b/frontend/app/v/[shortId]/[[...path]]/route.ts
@@ -30,16 +30,25 @@ function resolveSuffix(pathSegments: string[] | undefined): string | null {
     return "";
   }
 
-  if (pathSegments.length !== 1) {
+  // Legacy: /v/{shortId}/detail or /v/{shortId}/go
+  if (pathSegments.length === 1) {
+    const [segment] = pathSegments;
+    if (segment === "detail" || segment === "go") {
+      return `/${segment}`;
+    }
     return null;
   }
 
-  const [segment] = pathSegments;
-  if (segment !== "detail" && segment !== "go") {
-    return null;
+  // Path-based tracking: /v/{shortId}/{requestId}/{rank}[/detail|/go]
+  if (pathSegments.length === 2 || pathSegments.length === 3) {
+    const tail = pathSegments.length === 3 ? `/${pathSegments[2]}` : "";
+    if (tail && tail !== "/detail" && tail !== "/go") {
+      return null;
+    }
+    return `/${pathSegments[0]}/${pathSegments[1]}${tail}`;
   }
 
-  return `/${segment}`;
+  return null;
 }
 
 async function proxyTrackingRequest(


### PR DESCRIPTION
## Summary
- Frontend proxy returned 404 for new `/v/{shortId}/{requestId}/{rank}` URLs because `resolveSuffix` only allowed `/detail` and `/go`
- Update to recognize path-based tracking params and forward them transparently to the API backend
- Follows up on #135 which moved tracking params from query strings to URL path segments

## Test plan
- [x] All 6 vitest tests pass (including 2 new path-based tracking tests)
- [ ] Deploy frontend and verify `/v/{shortId}/{requestId}/{rank}` redirects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)