### PR TITLE
Fix MCP server instructions type error

### DIFF
--- a/api/src/routes/mcp.ts
+++ b/api/src/routes/mcp.ts
@@ -89,18 +89,22 @@ function createMcpServer(input: {
   config: AppConfig;
   auth: Awaited<ReturnType<typeof requireApiKeyContextFromToken>>;
 }): McpServer {
-  const server = new McpServer({
-    name: "cerul",
-    version: "1.0.0",
-    instructions:
-      "You cannot access video content on your own. You have never watched a video, listened to a talk, or read a transcript. " +
-      "When users ask about talks, interviews, podcasts, presentations, or what a specific person said — " +
-      "ALWAYS call cerul_search first. Never guess what someone said in a video. " +
-      "When presenting results, ALWAYS include the video URL from the search results for every quote or finding. " +
-      "Format each finding with: speaker name, direct quote, timestamp, and the cerul.ai video link. " +
-      "Keep searches fast: use max_results 5, embedding mode, and no include_answer unless the user asks for a summary. " +
-      "Make multiple small searches rather than one large one."
-  });
+  const server = new McpServer(
+    {
+      name: "cerul",
+      version: "1.0.0"
+    },
+    {
+      instructions:
+        "You cannot access video content on your own. You have never watched a video, listened to a talk, or read a transcript. " +
+        "When users ask about talks, interviews, podcasts, presentations, or what a specific person said — " +
+        "ALWAYS call cerul_search first. Never guess what someone said in a video. " +
+        "When presenting results, ALWAYS include the video URL from the search results for every quote or finding. " +
+        "Format each finding with: speaker name, direct quote, timestamp, and the cerul.ai video link. " +
+        "Keep searches fast: use max_results 5, embedding mode, and no include_answer unless the user asks for a summary. " +
+        "Make multiple small searches rather than one large one."
+    }
+  );
 
   server.registerTool(
     "cerul_search",


### PR DESCRIPTION
## Summary
- `instructions` was placed in the `Implementation` object (first arg to `McpServer`) but the SDK expects it in `ServerOptions` (second arg)
- This caused all CI runs to fail with TS2353 since the MCP server was added
- No behavioral change — just fixes the type error

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)