### PR TITLE
Adjust free-tier credits and default API key onboarding

### DIFF
--- a/api/src/routes/dashboard.ts
+++ b/api/src/routes/dashboard.ts
@@ -143,6 +143,7 @@ function normalizeApiKeySummary(record: Record<string, unknown> | null): Record<
     id: String(payload.id ?? ""),
     name: String(payload.name ?? ""),
     prefix: String(payload.prefix ?? ""),
+    raw_key: payload.raw_key == null ? null : String(payload.raw_key),
     created_at: payload.created_at ?? null,
     last_used_at: payload.last_used_at ?? null,
     is_active: Boolean(payload.is_active ?? false)
@@ -269,6 +270,7 @@ async function provisionUserProfileFromAuthUser(db: DatabaseClient, userId: stri
           monthly_credit_limit,
           rate_limit_per_sec,
           stripe_customer_id,
+          has_payment_method_on_file,
           stripe_subscription_id,
           billing_hold,
           auto_recharge_enabled,
@@ -292,6 +294,7 @@ async function fetchUserProfile(db: DatabaseClient, userId: string): Promise<Rec
           monthly_credit_limit,
           rate_limit_per_sec,
           stripe_customer_id,
+          has_payment_method_on_file,
           stripe_subscription_id,
           billing_hold,
           auto_recharge_enabled,
@@ -327,18 +330,20 @@ async function insertApiKey(
   userId: string,
   name: string,
   keyHash: string,
-  prefix: string
+  prefix: string,
+  rawKey: string
 ): Promise<Record<string, unknown>> {
   const row = await db.fetchrow(
     `
-      INSERT INTO api_keys (user_id, name, key_hash, prefix, is_active)
-      VALUES ($1, $2, $3, $4, TRUE)
-      RETURNING id, name, prefix, created_at, last_used_at, is_active
+      INSERT INTO api_keys (user_id, name, key_hash, prefix, raw_key, is_active)
+      VALUES ($1, $2, $3, $4, $5, TRUE)
+      RETURNING id, name, prefix, raw_key, created_at, last_used_at, is_active
     `,
     userId,
     name,
     keyHash,
-    prefix
+    prefix,
+    rawKey
   );
   if (!row) {
     apiError(500, "Failed to create API key.");
@@ -349,7 +354,7 @@ async function insertApiKey(
 async function listApiKeysForUser(db: DatabaseClient, userId: string): Promise<Record<string, unknown>[]> {
   const rows = await db.fetch(
     `
-      SELECT id, name, prefix, created_at, last_used_at, is_active
+      SELECT id, name, prefix, raw_key, created_at, last_used_at, is_active
       FROM api_keys
       WHERE user_id = $1
       ORDER BY created_at DESC
@@ -705,7 +710,14 @@ export function createDashboardRouter(): any {
     }
 
     const generated = await generateApiKey();
-    const created = await insertApiKey(db, session.userId, name, generated.keyHash, generated.prefix);
+    const created = await insertApiKey(
+      db,
+      session.userId,
+      name,
+      generated.keyHash,
+      generated.prefix,
+      generated.rawKey
+    );
     return c.json(
       {
         key_id: String(created.id),
@@ -1061,6 +1073,16 @@ export function createDashboardRouter(): any {
           stripeCustomerId,
           stripeSubscriptionId
         );
+        await db.execute(
+          `
+            UPDATE user_profiles
+            SET
+                has_payment_method_on_file = TRUE,
+                updated_at = NOW()
+            WHERE id = $1
+          `,
+          session.userId
+        );
 
         let notification = null;
         let invoiceId = normalizeExpandableId(checkoutSession.invoice);
@@ -1263,10 +1285,31 @@ export function createDashboardRouter(): any {
     const session = c.get("session") as DashboardSession;
     const profile = await fetchUserProfile(db, session.userId);
     if (!profile?.stripe_customer_id) {
+      await db.execute(
+        `
+          UPDATE user_profiles
+          SET
+              has_payment_method_on_file = FALSE,
+              updated_at = NOW()
+          WHERE id = $1
+        `,
+        session.userId
+      );
       return c.json({ methods: [] });
     }
     try {
       const methods = await listPaymentMethods(config, String(profile.stripe_customer_id));
+      await db.execute(
+        `
+          UPDATE user_profiles
+          SET
+              has_payment_method_on_file = $2,
+              updated_at = NOW()
+          WHERE id = $1
+        `,
+        session.userId,
+        methods.length > 0
+      );
       return c.json({ methods });
     } catch (error) {
       if (error instanceof StripeServiceError) {

--- a/api/src/routes/webhooks.ts
+++ b/api/src/routes/webhooks.ts
@@ -127,12 +127,33 @@ async function processStripeEvent(db: DatabaseClient, config: any, event: Record
 
   if (eventType === "checkout.session.completed" || eventType === "checkout.session.async_payment_succeeded") {
     const metadata = asRecord(eventObject.metadata);
+    const mode = asString(eventObject.mode) ?? "";
+    if (mode === "setup") {
+      if (!isCheckoutComplete(eventObject)) {
+        return;
+      }
+      const stripeCustomerId = asString(eventObject.customer);
+      if (!stripeCustomerId) {
+        return;
+      }
+      await db.execute(
+        `
+          UPDATE user_profiles
+          SET
+              has_payment_method_on_file = TRUE,
+              updated_at = NOW()
+          WHERE stripe_customer_id = $1
+        `,
+        stripeCustomerId
+      );
+      return;
+    }
+
     const userId = asString(metadata.user_id) ?? asString(eventObject.client_reference_id);
     if (!userId) {
       return;
     }
 
-    const mode = asString(eventObject.mode) ?? "";
     if (mode === "subscription") {
       if (!isCheckoutComplete(eventObject) || !isSubscriptionCheckoutReady(eventObject)) {
         return;
@@ -142,6 +163,16 @@ async function processStripeEvent(db: DatabaseClient, config: any, event: Record
         userId,
         asString(eventObject.customer),
         asString(eventObject.subscription)
+      );
+      await db.execute(
+        `
+          UPDATE user_profiles
+          SET
+              has_payment_method_on_file = TRUE,
+              updated_at = NOW()
+          WHERE id = $1
+        `,
+        userId
       );
       return;
     }
@@ -177,6 +208,16 @@ async function processStripeEvent(db: DatabaseClient, config: any, event: Record
     if (!stripeCustomerId) {
       return;
     }
+    await db.execute(
+      `
+        UPDATE user_profiles
+        SET
+            has_payment_method_on_file = TRUE,
+            updated_at = NOW()
+        WHERE stripe_customer_id = $1
+      `,
+      stripeCustomerId
+    );
     await syncSubscriptionStatus(db, stripeCustomerId, {
       id: asString(eventObject.subscription),
       status: "active"

--- a/api/src/services/billing-catalog.ts
+++ b/api/src/services/billing-catalog.ts
@@ -57,7 +57,7 @@ export function getProProduct(config: AppConfig): BillingCatalogProduct {
 
 export function includedCreditsForPlan(planCode: BillingPlanCode): number {
   if (planCode === "free") {
-    return 0;
+    return 300;
   }
   if (planCode === "pro") {
     return 5_000;
@@ -71,7 +71,8 @@ export const TOPUP_STEP_PRICE_CENTS = (TOPUP_RATE_PER_1K_CENTS * TOPUP_CREDIT_ST
 export const SIGNUP_BONUS_CREDITS = 100;
 export const FREE_DAILY_SEARCHES = 10;
 
-export const REFERRAL_BONUS_CREDITS = 100;
+export const REFERRAL_INVITEE_BONUS = 100;
+export const REFERRAL_INVITER_BONUS = 200;
 export const REFERRAL_REWARD_DELAY_DAYS = 0;
 export const BONUS_CREDIT_EXPIRY_DAYS = 90;
 export const MAX_REFERRALS_PER_USER = 100;

--- a/api/src/services/billing.ts
+++ b/api/src/services/billing.ts
@@ -9,9 +9,10 @@ import {
   includedCreditsForPlan,
   MAX_REFERRALS_PER_USER,
   normalizePlanCode,
-  REFERRAL_BONUS_CREDITS,
   REFERRAL_CODE_MAX_LENGTH,
   REFERRAL_CODE_MIN_LENGTH,
+  REFERRAL_INVITEE_BONUS,
+  REFERRAL_INVITER_BONUS,
   REFERRAL_REWARD_DELAY_DAYS,
   SIGNUP_BONUS_CREDITS,
   topupAmountCents,
@@ -33,7 +34,7 @@ export class BillingHoldError extends Error {
 }
 
 export const DEFAULT_MONTHLY_CREDIT_LIMITS: Record<string, number> = {
-  free: 0,
+  free: 300,
   pro: 5_000,
   enterprise: 100_000
 };
@@ -77,6 +78,7 @@ type UserBillingProfile = {
   billing_hold: boolean;
   stripe_customer_id: string | null;
   stripe_subscription_id: string | null;
+  has_payment_method_on_file: boolean;
   auto_recharge_enabled: boolean;
   auto_recharge_threshold: number;
   auto_recharge_quantity: number;
@@ -188,6 +190,8 @@ type BillingCatalogState = {
   referral: {
     code: string;
     bonus_credits: number;
+    invitee_bonus_credits: number;
+    inviter_bonus_credits: number;
     reward_delay_days: number;
     redeemed_code: string | null;
     status: string | null;
@@ -320,6 +324,7 @@ async function fetchUserBillingProfile(db: DatabaseClient, userId: string): Prom
           billing_hold,
           stripe_customer_id,
           stripe_subscription_id,
+          has_payment_method_on_file,
           auto_recharge_enabled,
           auto_recharge_threshold,
           auto_recharge_quantity
@@ -340,10 +345,25 @@ async function fetchUserBillingProfile(db: DatabaseClient, userId: string): Prom
     billing_hold: Boolean(row.billing_hold),
     stripe_customer_id: row.stripe_customer_id == null ? null : String(row.stripe_customer_id),
     stripe_subscription_id: row.stripe_subscription_id == null ? null : String(row.stripe_subscription_id),
+    has_payment_method_on_file: Boolean(row.has_payment_method_on_file),
     auto_recharge_enabled: Boolean(row.auto_recharge_enabled),
     auto_recharge_threshold: normalizeInteger(row.auto_recharge_threshold, 100),
     auto_recharge_quantity: Math.max(normalizeInteger(row.auto_recharge_quantity, 1_000), 1_000)
   };
+}
+
+function effectiveMonthlyCreditLimit(profile: UserBillingProfile): number {
+  const planCode = normalizePlanCode(profile.tier);
+  const configuredLimit = normalizeInteger(
+    profile.monthly_credit_limit,
+    monthlyCreditLimitForTier(profile.tier)
+  );
+
+  if (planCode === "free" && !profile.has_payment_method_on_file) {
+    return 0;
+  }
+
+  return configuredLimit;
 }
 
 async function expireElapsedCreditGrants(db: DatabaseClient, userId: string): Promise<void> {
@@ -471,15 +491,14 @@ async function ensureCurrentPeriodGrant(
   }
 
   const [periodStart, periodEnd] = currentBillingPeriod(referenceDate);
-  const totalCredits = normalizeInteger(
-    profile.monthly_credit_limit,
-    includedCreditsForPlan(planCode)
-  );
+  const totalCredits = planCode === "free"
+    ? effectiveMonthlyCreditLimit(profile)
+    : normalizeInteger(profile.monthly_credit_limit, includedCreditsForPlan(planCode));
   if (totalCredits <= 0) {
     return;
   }
-
   const grantType: CreditGrantType = planCode === "free" ? "free_monthly" : "subscription_monthly";
+
   await createCreditGrant(db, {
     userId,
     grantKey: `${grantType}:${userId}:${periodStart}`,
@@ -862,7 +881,7 @@ async function awardDueReferralCredits(db: DatabaseClient): Promise<void> {
       grantKey: `referral_bonus:${redemption.id}:referrer`,
       grantType: "referral_bonus",
       planCode: null,
-      totalCredits: REFERRAL_BONUS_CREDITS,
+      totalCredits: REFERRAL_INVITER_BONUS,
       expiresAt,
       referralRedemptionId: String(redemption.id),
       metadata: {
@@ -874,7 +893,7 @@ async function awardDueReferralCredits(db: DatabaseClient): Promise<void> {
       grantKey: `referral_bonus:${redemption.id}:referee`,
       grantType: "referral_bonus",
       planCode: null,
-      totalCredits: REFERRAL_BONUS_CREDITS,
+      totalCredits: REFERRAL_INVITEE_BONUS,
       expiresAt,
       referralRedemptionId: String(redemption.id),
       metadata: {
@@ -1718,7 +1737,7 @@ export async function redeemReferralCode(
       grantKey: `referral_bonus:${redemption.id}:referrer`,
       grantType: "referral_bonus",
       planCode: null,
-      totalCredits: REFERRAL_BONUS_CREDITS,
+      totalCredits: REFERRAL_INVITER_BONUS,
       expiresAt,
       referralRedemptionId: String(redemption.id),
       metadata: { role: "referrer" }
@@ -1728,7 +1747,7 @@ export async function redeemReferralCode(
       grantKey: `referral_bonus:${redemption.id}:referee`,
       grantType: "referral_bonus",
       planCode: null,
-      totalCredits: REFERRAL_BONUS_CREDITS,
+      totalCredits: REFERRAL_INVITEE_BONUS,
       expiresAt,
       referralRedemptionId: String(redemption.id),
       metadata: { role: "referee" }
@@ -1767,7 +1786,9 @@ export async function fetchBillingCatalogState(
       expiring_credits: wallet.expiring_credits,
       referral: {
         code: referralCode.code,
-        bonus_credits: REFERRAL_BONUS_CREDITS,
+        bonus_credits: REFERRAL_INVITEE_BONUS,
+        invitee_bonus_credits: REFERRAL_INVITEE_BONUS,
+        inviter_bonus_credits: REFERRAL_INVITER_BONUS,
         reward_delay_days: REFERRAL_REWARD_DELAY_DAYS,
         redeemed_code: redemption?.referee_code ?? null,
         status: redemption?.status ?? null,
@@ -2033,7 +2054,7 @@ async function consumeSearchUsage(
       userId: input.userId,
       periodStart,
       periodEnd,
-      creditsLimit: normalizeInteger(profile.monthly_credit_limit, monthlyCreditLimitForTier(profile.tier)),
+      creditsLimit: effectiveMonthlyCreditLimit(profile),
       creditsUsed: chargedCredits
     });
 
@@ -2220,7 +2241,7 @@ export async function fetchUsageSummary(
     return {
       tier: profile.tier,
       plan_code: normalizePlanCode(profile.tier),
-      credits_limit: normalizeInteger(profile.monthly_credit_limit, monthlyCreditLimitForTier(profile.tier)),
+      credits_limit: effectiveMonthlyCreditLimit(profile),
       credits_used: normalizeInteger(summary.credits_used, 0),
       credits_remaining: wallet.wallet_balance,
       wallet_balance: wallet.wallet_balance,

--- a/db/migrations/021_credit_adjustments.sql
+++ b/db/migrations/021_credit_adjustments.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+ALTER TABLE user_profiles
+    ALTER COLUMN monthly_credit_limit SET DEFAULT 300;
+
+ALTER TABLE user_profiles
+    ADD COLUMN IF NOT EXISTS has_payment_method_on_file BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS raw_key TEXT;
+
+UPDATE user_profiles
+SET monthly_credit_limit = 300
+WHERE tier = 'free';
+
+UPDATE user_profiles
+SET has_payment_method_on_file = TRUE
+WHERE stripe_subscription_id IS NOT NULL
+   OR EXISTS (
+       SELECT 1
+       FROM billing_orders
+       WHERE billing_orders.user_id = user_profiles.id
+         AND billing_orders.order_kind = 'subscription'
+         AND billing_orders.status = 'paid'
+         AND billing_orders.stripe_customer_id IS NOT NULL
+   );
+
+COMMIT;

--- a/docs/credit-adjustment-plan.md
+++ b/docs/credit-adjustment-plan.md
@@ -1,0 +1,125 @@
+# New User Experience & Credit Adjustment Plan
+
+## Background
+
+New users currently receive 1,100 spendable credits upon registration (1,000 monthly included + 100 signup bonus), which is too generous. This plan adjusts credit allocation to be more sustainable, and rebalances referral rewards to better incentivize invitations.
+
+## Current State
+
+| Item | Value |
+|------|-------|
+| Monthly included credits (free tier) | 1,000 |
+| Signup bonus (all users) | 100 |
+| Referral bonus — invitee | 100 |
+| Referral bonus — inviter | 100 |
+| Daily free uses | 10 |
+
+**Current day-1 credits (no invite code):** 1,000 + 100 + 10 = 1,110
+**Current day-1 credits (with invite code):** 1,000 + 100 + 100 + 10 = 1,210
+
+## Target State
+
+| Item | Current | New |
+|------|---------|-----|
+| Monthly included credits (free tier) | 1,000 | **300 (requires credit card)** |
+| Signup bonus (all users) | 100 | **100 (unchanged)** |
+| Referral bonus — invitee | 100 | **100 (unchanged)** |
+| Referral bonus — inviter | 100 | **200** |
+| Daily free uses | 10 | 10 (unchanged) |
+
+**New day-1 credits (no invite code):** 100 (signup) + 10 (daily) = 110
+**New day-1 credits (with invite code):** 100 (signup) + 100 (referral) + 10 (daily) = **210**
+**After binding credit card (monthly):** +300 per month
+
+## Changes Required
+
+### 1. Adjust monthly included credits for free tier: 1,000 → 300, gated by credit card
+- Database: `user_profiles.monthly_credit_limit` default value `1000` → `300`
+- **Key change:** Monthly credits are NOT granted on registration. Only start granting after user has bound a credit card (payment method on file)
+- Billing service: `ensureCurrentPeriodGrant()` — add a check: skip grant if user has no payment method bound
+- The first monthly grant starts from the month the credit card is bound (not retroactive)
+- Need a migration to update default and existing free-tier users' `monthly_credit_limit`
+
+### 2. Increase inviter referral bonus: 100 → 200
+- Split `REFERRAL_BONUS_CREDITS` into two separate constants:
+  - `REFERRAL_INVITEE_BONUS = 100`
+  - `REFERRAL_INVITER_BONUS = 200`
+- Update `redeemReferralCode()` in `api/src/services/billing.ts` to use different amounts for referrer vs referee
+
+### 3. Auto-create default API key for new users
+
+New users should automatically receive a default API key upon registration, so they can start using the API immediately without manual setup.
+
+- In the user registration hook (same place that grants signup bonus), auto-generate an API key
+- Key name: `"Default"`
+- The raw key is shown only once — store the SHA256 hash as usual
+- The raw key should be visible in the dashboard on first login (or at least copyable from the API keys page)
+
+### 4. Fix API key management UI
+
+The API keys management page has two UI issues:
+
+**a) Eye icon (reveal key) is broken:**
+- Clicking the eye icon should reveal the full API key plaintext temporarily
+- After a few seconds (e.g. 3-5s), it should auto-hide back to the masked format
+- This was previously implemented but is no longer working
+
+**b) Missing copy button:**
+- Add a copy-to-clipboard icon/button for each API key
+- Position: before the delete button
+- On click: copy the key to clipboard and show brief feedback (e.g. tooltip "Copied!")
+
+### 5. API Playground UI improvements
+
+**a) Send button loading state:**
+- Rename "Send request" → "Send"
+- While request is in flight, show a spinning loader on the button (disable button to prevent duplicate requests)
+- On completion, restore button to normal state
+
+**b) Refactor code snippets to use official SDKs:**
+
+Current state: all language tabs (Python, JS, Shell, Go) generate raw HTTP requests to `/v1/search`.
+
+Target: Python and JS should use official SDK packages. Go stays as raw HTTP (no SDK yet). Shell (curl) unchanged.
+
+**Python** — use `cerul` PyPI package:
+```python
+from cerul import Cerul
+
+client = Cerul(api_key="YOUR_API_KEY")
+result = client.search(query="...", max_results=5)
+
+for r in result:
+    print(r.title, r.url)
+```
+
+**JavaScript** — use `cerul` npm package:
+```javascript
+import { cerul } from "cerul";
+
+const client = cerul({ apiKey: "YOUR_API_KEY" });
+const result = await client.search({
+  query: "...",
+  max_results: 5,
+});
+
+for (const r of result.results) {
+  console.log(r.title, r.url);
+}
+```
+
+**Go** — keep raw HTTP request (no SDK available)
+
+**Shell (curl)** — keep as-is
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `api/src/services/billing-catalog.ts` | Add `REFERRAL_INVITEE_BONUS`, `REFERRAL_INVITER_BONUS`; remove or keep `REFERRAL_BONUS_CREDITS` |
+| `api/src/services/billing.ts` | Split referral bonus amounts for inviter/invitee; handle 0 monthly credits |
+| `db/migrations/XXX_adjust_credits.sql` | New migration: update `monthly_credit_limit` default to 0 and existing free-tier values |
+| `frontend/lib/auth-db.ts` or `auth-server.ts` | Auto-create default API key in user registration hook |
+| API key creation service | Ensure key generation logic can be called from registration flow |
+| API keys management UI component | Fix eye icon reveal/auto-hide; add copy button before delete |
+| `frontend/components/dashboard/playground-screen.tsx` | Rename button, add loading spinner, refactor Python/JS snippets to use SDK |

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -92,8 +92,8 @@ export default function DocsPage() {
                     Get your API key
                   </h2>
                   <p className="mt-4 max-w-3xl text-[15px] leading-8 text-[var(--foreground-secondary)]">
-                    Sign up at cerul.ai and create an API key from the dashboard.
-                    The free tier gives you 1,000 credits per month — no credit card required.
+                    Sign up at cerul.ai and your default API key is ready in the dashboard.
+                    New accounts start with 100 signup credits and 10 free searches per day. Add a credit card when you want the 300-credit monthly free tier.
                   </p>
                   <div className="mt-6 flex flex-wrap gap-3">
                     <Link href="/login?mode=signup" className="button-primary">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -742,6 +742,15 @@ button:focus-visible,
   }
 }
 
+.playground-spinner {
+  animation: playground-spin 1s linear infinite !important;
+}
+
+@keyframes playground-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 @keyframes spin-slow {
   from {
     transform: rotate(0deg);

--- a/frontend/components/dashboard/account-screen.tsx
+++ b/frontend/components/dashboard/account-screen.tsx
@@ -161,7 +161,7 @@ export function DashboardAccountScreen() {
               </button>
             </div>
             <p className="mt-2 text-xs text-[var(--foreground-secondary)]">
-              Both get {formatNumber(catalog.referral.bonusCredits)} bonus credits
+              Invitees get {formatNumber(catalog.referral.inviteeBonusCredits)} and inviters get {formatNumber(catalog.referral.inviterBonusCredits)}
             </p>
           </div>
         ) : null}

--- a/frontend/components/dashboard/api-key-row.tsx
+++ b/frontend/components/dashboard/api-key-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { DashboardApiKey } from "@/lib/api";
 import { formatDashboardDateTime } from "@/lib/dashboard";
 
@@ -11,16 +12,110 @@ type ApiKeyRowProps = {
   isLastKey?: boolean;
 };
 
+function IconEye({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        d="M2.036 12.322a1 1 0 0 1 0-.644C3.423 7.51 7.36 4.5 12 4.5s8.577 3.01 9.964 7.178a1 1 0 0 1 0 .644C20.577 16.49 16.64 19.5 12 19.5s-8.577-3.01-9.964-7.178Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}
+
+function IconEyeSlash({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        d="m3 3 18 18M10.585 10.587A2 2 0 0 0 13.414 13.4M9.88 5.09A10.97 10.97 0 0 1 12 4.5c4.64 0 8.577 3.01 9.964 7.178a1 1 0 0 1 0 .644 11.052 11.052 0 0 1-4.293 5.226M6.228 6.228A11.053 11.053 0 0 0 2.036 11.68a1 1 0 0 0 0 .644C3.423 16.49 7.36 19.5 12 19.5c1.617 0 3.156-.365 4.534-1.02"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}
+
+function IconCopy({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.334a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}
+
+function IconCheck({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path d="M4.5 12.75l6 6 9-13.5" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}
+
 function IconTrash({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
+      <path
+        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
     </svg>
   );
 }
 
 function maskedKey(prefix: string): string {
   return `${prefix}${"*".repeat(28)}`;
+}
+
+function ActionButton({
+  title,
+  disabled,
+  onClick,
+  children,
+}: {
+  title: string;
+  disabled?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className="inline-flex h-9 w-9 items-center justify-center rounded-full text-[var(--foreground-tertiary)] transition hover:bg-[rgba(36,29,21,0.06)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-30"
+    >
+      {children}
+    </button>
+  );
+}
+
+function CopyFeedback({ visible }: { visible: boolean }) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded-full bg-[var(--foreground)] px-2 py-1 text-[10px] font-medium text-white shadow-sm">
+      Copied!
+    </span>
+  );
 }
 
 export function ApiKeyRow({
@@ -30,21 +125,113 @@ export function ApiKeyRow({
   compact,
   isLastKey,
 }: ApiKeyRowProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
+  const revealTimeoutRef = useRef<number | null>(null);
+  const copyTimeoutRef = useRef<number | null>(null);
+  const canAccessRawKey = Boolean(apiKey.rawKey);
+
+  useEffect(() => {
+    return () => {
+      if (revealTimeoutRef.current !== null) {
+        window.clearTimeout(revealTimeoutRef.current);
+      }
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  function handleReveal() {
+    if (!apiKey.rawKey) {
+      return;
+    }
+    if (isVisible) {
+      setIsVisible(false);
+      if (revealTimeoutRef.current !== null) {
+        window.clearTimeout(revealTimeoutRef.current);
+        revealTimeoutRef.current = null;
+      }
+      return;
+    }
+    setIsVisible(true);
+    if (revealTimeoutRef.current !== null) {
+      window.clearTimeout(revealTimeoutRef.current);
+    }
+    revealTimeoutRef.current = window.setTimeout(() => {
+      setIsVisible(false);
+      revealTimeoutRef.current = null;
+    }, 4000);
+  }
+
+  async function handleCopy() {
+    if (!apiKey.rawKey) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(apiKey.rawKey);
+      setIsCopied(true);
+
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = window.setTimeout(() => {
+        setIsCopied(false);
+        copyTimeoutRef.current = null;
+      }, 2000);
+    } catch {
+      setIsCopied(false);
+    }
+  }
+
+  const displayKey = isVisible && apiKey.rawKey ? apiKey.rawKey : maskedKey(apiKey.prefix);
+  const rawKeyTitle = canAccessRawKey ? "Plaintext key will auto-hide in 4 seconds." : "Plaintext unavailable for this key.";
+  const deleteTitle = isLastKey
+    ? "Cannot delete last key"
+    : isPending
+      ? "Revoking..."
+      : apiKey.isActive
+        ? "Delete key"
+        : "Already revoked";
+
+  const actions = (
+    <div className="flex items-center justify-end gap-1">
+      <ActionButton
+        title={isVisible ? "Visible now" : rawKeyTitle}
+        disabled={!canAccessRawKey}
+        onClick={handleReveal}
+      >
+        {isVisible ? <IconEyeSlash className="h-[18px] w-[18px]" /> : <IconEye className="h-[18px] w-[18px]" />}
+      </ActionButton>
+      <div className="relative">
+        <CopyFeedback visible={isCopied} />
+        <ActionButton
+          title={isCopied ? "Copied!" : canAccessRawKey ? "Copy key" : "Plaintext unavailable for this key."}
+          disabled={!canAccessRawKey}
+          onClick={() => void handleCopy()}
+        >
+          {isCopied ? <IconCheck className="h-[18px] w-[18px]" /> : <IconCopy className="h-[18px] w-[18px]" />}
+        </ActionButton>
+      </div>
+      <ActionButton
+        title={deleteTitle}
+        disabled={isPending || !apiKey.isActive || isLastKey}
+        onClick={() => onRevoke(apiKey)}
+      >
+        <IconTrash className="h-[18px] w-[18px]" />
+      </ActionButton>
+    </div>
+  );
+
   if (compact) {
     return (
-      <div className="flex items-center justify-between rounded-lg border border-[var(--border)] px-3 py-2.5">
+      <div className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border)] px-3 py-2.5">
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium text-[var(--foreground)]">{apiKey.name}</p>
-          <p className="text-xs text-[var(--foreground-tertiary)]">{maskedKey(apiKey.prefix)}</p>
+          <p className="break-all font-mono text-xs text-[var(--foreground-tertiary)]">{displayKey}</p>
         </div>
-        <button
-          type="button"
-          onClick={() => onRevoke(apiKey)}
-          disabled={isPending || !apiKey.isActive || isLastKey}
-          className="ml-2 text-xs text-[var(--foreground-tertiary)] hover:text-[var(--error)] disabled:opacity-50"
-        >
-          {isPending ? "..." : apiKey.isActive ? "Revoke" : "Revoked"}
-        </button>
+        {actions}
       </div>
     );
   }
@@ -55,25 +242,15 @@ export function ApiKeyRow({
         <p className="font-medium text-[var(--foreground)]">{apiKey.name}</p>
       </td>
       <td className="px-5 py-4">
-        <div className="inline-flex items-center gap-0.5 rounded-[10px] border border-[var(--border)] bg-[var(--background-elevated,rgba(255,250,242,1))] px-3 py-1.5">
-          <code className="font-mono text-[13px] text-[var(--foreground)]">{maskedKey(apiKey.prefix)}</code>
+        <div className="inline-flex max-w-full items-center gap-0.5 rounded-[10px] border border-[var(--border)] bg-[var(--background-elevated,rgba(255,250,242,1))] px-3 py-1.5">
+          <code className="max-w-[360px] break-all whitespace-normal font-mono text-[13px] text-[var(--foreground)]">
+            {displayKey}
+          </code>
         </div>
       </td>
       <td className="px-5 py-4 text-sm">{formatDashboardDateTime(apiKey.createdAt)}</td>
       <td className="px-5 py-4 text-sm">{formatDashboardDateTime(apiKey.lastUsedAt)}</td>
-      <td className="px-5 py-4 text-right">
-        <div className="flex items-center justify-end gap-1">
-          <button
-            type="button"
-            onClick={() => onRevoke(apiKey)}
-            disabled={isPending || !apiKey.isActive || isLastKey}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-[var(--foreground-tertiary)] transition hover:bg-[rgba(191,91,70,0.08)] hover:text-[var(--error,#bf5b46)] disabled:cursor-not-allowed disabled:opacity-30"
-            title={isLastKey ? "Cannot delete last key" : isPending ? "Revoking..." : apiKey.isActive ? "Delete key" : "Already revoked"}
-          >
-            <IconTrash className="h-[18px] w-[18px]" />
-          </button>
-        </div>
-      </td>
+      <td className="px-5 py-4 text-right">{actions}</td>
     </tr>
   );
 }

--- a/frontend/components/dashboard/create-key-dialog.tsx
+++ b/frontend/components/dashboard/create-key-dialog.tsx
@@ -154,7 +154,7 @@ export function CreateKeyDialog({
           <div className="mt-6 space-y-4">
             <div className="rounded-[20px] border border-[var(--border-brand)] bg-[var(--brand-subtle)] px-5 py-5">
               <p className="font-mono text-xs uppercase tracking-[0.16em] text-[var(--brand-bright)]">
-                Visible once
+                Raw key
               </p>
               <p className="mt-3 font-mono text-sm leading-7 break-all text-[var(--foreground)]">
                 {createdKey.rawKey}
@@ -162,8 +162,8 @@ export function CreateKeyDialog({
             </div>
 
             <p className="text-sm leading-6 text-[var(--foreground-secondary)]">
-              Cerul only returns the raw key once. Copy it now and store it in your
-              secrets manager before closing this dialog.
+              Copy it now for immediate use. You can also reveal or copy the masked
+              key later from the dashboard if needed.
             </p>
 
             {error ? (

--- a/frontend/components/dashboard/home-screen.tsx
+++ b/frontend/components/dashboard/home-screen.tsx
@@ -190,6 +190,7 @@ export function DashboardHomeScreen() {
                 isPending={pendingKeyId === key.id}
                 onRevoke={handleRevoke}
                 compact
+                isLastKey={keys.filter((item) => item.isActive).length <= 1}
               />
             ))}
           </div>

--- a/frontend/components/dashboard/keys-screen.tsx
+++ b/frontend/components/dashboard/keys-screen.tsx
@@ -53,7 +53,7 @@ export function DashboardKeysScreen() {
     <DashboardLayout
       currentPath="/dashboard/keys"
       title="API Keys"
-      description="Secrets are shown once at creation and never again."
+      description="Plaintext keys stay masked by default and auto-hide after reveal."
       actions={
         <button type="button" className="button-primary" onClick={() => setIsDialogOpen(true)}>
           + New Key

--- a/frontend/components/dashboard/playground-screen.tsx
+++ b/frontend/components/dashboard/playground-screen.tsx
@@ -35,34 +35,33 @@ function buildCodeSnippet(lang: CodeLang, query: string, authToken: string): str
   const q = query || "your search query here";
 
   if (lang === "python") {
-    return `# To install: pip install requests
-import requests
+    return `# To install: pip install cerul
+from cerul import Cerul
 
-response = requests.post(
-    "https://api.cerul.ai/v1/search",
-    headers={"Authorization": "Bearer ${authToken}"},
-    json={
-        "query": ${JSON.stringify(q)},
-        "max_results": 5,
-    },
+client = Cerul(api_key="${authToken}")
+
+result = client.search(
+    query=${JSON.stringify(q)},
+    max_results=5,
 )
-print(response.json())`;
+
+for r in result:
+    print(r.title, r.url)`;
   }
 
   if (lang === "javascript") {
-    return `const response = await fetch("https://api.cerul.ai/v1/search", {
-  method: "POST",
-  headers: {
-    "Authorization": "Bearer ${authToken}",
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    query: ${JSON.stringify(q)},
-    max_results: 5,
-  }),
+    return `import { cerul } from "cerul";
+
+const client = cerul({ apiKey: "${authToken}" });
+
+const result = await client.search({
+  query: ${JSON.stringify(q)},
+  max_results: 5,
 });
-const data = await response.json();
-console.log(data);`;
+
+for (const r of result.results) {
+  console.log(r.title, r.url);
+}`;
   }
 
   if (lang === "go") {
@@ -72,8 +71,8 @@ import (
     "bytes"
     "encoding/json"
     "fmt"
-    "net/http"
     "io"
+    "net/http"
 )
 
 func main() {
@@ -81,9 +80,11 @@ func main() {
         "query":       ${JSON.stringify(q)},
         "max_results": 5,
     })
-    req, _ := http.NewRequest("POST",
+    req, _ := http.NewRequest(
+        "POST",
         "https://api.cerul.ai/v1/search",
-        bytes.NewBuffer(body))
+        bytes.NewBuffer(body),
+    )
     req.Header.Set("Authorization", "Bearer ${authToken}")
     req.Header.Set("Content-Type", "application/json")
 
@@ -735,10 +736,10 @@ export function PlaygroundScreen() {
               {isLoading ? (
                 <span className="flex items-center justify-center gap-2">
                   <IconSpinner className="h-5 w-5" />
-                  Processing...
+                  Sending...
                 </span>
               ) : (
-                "Send Request"
+                "Send"
               )}
             </button>
 

--- a/frontend/components/dashboard/playground-screen.tsx
+++ b/frontend/components/dashboard/playground-screen.tsx
@@ -272,9 +272,9 @@ function IconThumbDown({ className, filled }: { className?: string; filled?: boo
 
 function IconSpinner({ className }: { className?: string }) {
   return (
-    <svg className={`animate-spin ${className ?? ""}`} fill="none" viewBox="0 0 24 24">
-      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4Z" />
+    <svg className={`playground-spinner ${className ?? ""}`} fill="none" viewBox="0 0 24 24">
+      <circle opacity="0.2" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+      <path stroke="currentColor" strokeWidth="3" strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
     </svg>
   );
 }
@@ -604,8 +604,8 @@ export function PlaygroundScreen() {
   );
 
   const codeSnippetForCopy = useMemo(
-    () => buildCodeSnippet(codeLang, query, "<YOUR_API_KEY>"),
-    [codeLang, query],
+    () => buildCodeSnippet(codeLang, query, selectedKey?.rawKey ?? maskKey(selectedKey?.prefix ?? "cerul_xxxx")),
+    [codeLang, query, selectedKey?.rawKey, selectedKey?.prefix],
   );
 
   async function handleSearch() {
@@ -729,9 +729,9 @@ export function PlaygroundScreen() {
             {/* Send button */}
             <button
               type="button"
-              disabled={isLoading || !query.trim() || keys.length === 0 || !selectedKeyId}
+              disabled={!isLoading && (!query.trim() || keys.length === 0 || !selectedKeyId)}
               onClick={() => void handleSearch()}
-              className="button-primary w-full"
+              className={`button-primary w-full ${isLoading ? "!opacity-100 pointer-events-none" : ""}`}
             >
               {isLoading ? (
                 <span className="flex items-center justify-center gap-2">

--- a/frontend/components/dashboard/settings-screen.tsx
+++ b/frontend/components/dashboard/settings-screen.tsx
@@ -149,7 +149,9 @@ export function DashboardSettingsScreen() {
     setIsRedeemingReferral(true); setReferralError(null); setReferralSuccess(null);
     try {
       await billing.redeemReferral(code);
-      setReferralSuccess(`Code applied! ${formatNumber(catalog?.referral.bonusCredits ?? 100)} credits added.`);
+      setReferralSuccess(
+        `Code applied! ${formatNumber(catalog?.referral.inviteeBonusCredits ?? 100)} credits added.`,
+      );
       setReferralInput("");
       void billing.getCatalog().then(setCatalog).catch(() => {});
       void refresh();
@@ -276,7 +278,7 @@ export function DashboardSettingsScreen() {
                 </div>
 
                 <p className="mt-2 text-xs text-[var(--foreground-tertiary)]">
-                  Both sides get {formatNumber(referral?.bonusCredits ?? 100)} bonus credits instantly. Credits expire in 90 days.
+                  Invitees get {formatNumber(referral?.inviteeBonusCredits ?? 100)} credits and inviters get {formatNumber(referral?.inviterBonusCredits ?? 200)} credits instantly. Credits expire in 90 days.
                 </p>
               </div>
 

--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -131,6 +131,7 @@ describe("dashboard API client", () => {
               id: "key_1",
               name: "Primary key",
               prefix: "cerul_abcd1234",
+              raw_key: "cerul_full_secret_123",
               created_at: "2026-03-01T10:00:00Z",
               last_used_at: null,
               is_active: true,
@@ -151,6 +152,7 @@ describe("dashboard API client", () => {
         id: "key_1",
         name: "Primary key",
         prefix: "cerul_abcd1234",
+        rawKey: "cerul_full_secret_123",
         createdAt: "2026-03-01T10:00:00Z",
         lastUsedAt: null,
         isActive: true,
@@ -369,6 +371,8 @@ describe("dashboard API client", () => {
           referral: {
             code: "CRL1A2B3C",
             bonus_credits: 100,
+            invitee_bonus_credits: 100,
+            inviter_bonus_credits: 200,
             reward_delay_days: 0,
             redeemed_code: null,
             status: null,
@@ -406,6 +410,8 @@ describe("dashboard API client", () => {
       referral: {
         code: "CRL1A2B3C",
         bonusCredits: 100,
+        inviteeBonusCredits: 100,
+        inviterBonusCredits: 200,
         rewardDelayDays: 0,
         redeemedCode: null,
         status: null,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -107,6 +107,8 @@ type BillingCatalogWire = {
   referral?: {
     code?: string;
     bonus_credits?: number;
+    invitee_bonus_credits?: number;
+    inviter_bonus_credits?: number;
     reward_delay_days?: number;
     redeemed_code?: string | null;
     status?: string | null;
@@ -201,6 +203,7 @@ export type DashboardApiKey = {
   id: string;
   name: string;
   prefix: string;
+  rawKey: string | null;
   createdAt: string;
   lastUsedAt: string | null;
   isActive: boolean;
@@ -325,6 +328,8 @@ export type BillingCatalog = {
   referral: {
     code: string;
     bonusCredits: number;
+    inviteeBonusCredits: number;
+    inviterBonusCredits: number;
     rewardDelayDays: number;
     redeemedCode: string | null;
     status: string | null;
@@ -527,6 +532,9 @@ function isApiKeyWire(value: unknown): value is ApiKeyWire {
     typeof value.id === "string" &&
     typeof value.name === "string" &&
     typeof value.prefix === "string" &&
+    (value.raw_key === undefined ||
+      value.raw_key === null ||
+      typeof value.raw_key === "string") &&
     typeof value.created_at === "string" &&
     (value.last_used_at === undefined ||
       value.last_used_at === null ||
@@ -624,6 +632,7 @@ function normalizeApiKey(input: ApiKeyWire): DashboardApiKey {
     id: input.id,
     name: input.name,
     prefix: input.prefix,
+    rawKey: input.raw_key ?? null,
     createdAt: input.created_at,
     lastUsedAt: input.last_used_at ?? null,
     isActive: input.is_active ?? true,
@@ -844,6 +853,18 @@ function normalizeBillingCatalog(payload: unknown): BillingCatalog {
         typeof referral.bonus_credits === "number"
           ? referral.bonus_credits
           : 0,
+      inviteeBonusCredits:
+        typeof referral.invitee_bonus_credits === "number"
+          ? referral.invitee_bonus_credits
+          : typeof referral.bonus_credits === "number"
+            ? referral.bonus_credits
+            : 0,
+      inviterBonusCredits:
+        typeof referral.inviter_bonus_credits === "number"
+          ? referral.inviter_bonus_credits
+          : typeof referral.bonus_credits === "number"
+            ? referral.bonus_credits
+            : 0,
       rewardDelayDays:
         typeof referral.reward_delay_days === "number"
           ? referral.reward_delay_days

--- a/frontend/lib/auth-db.ts
+++ b/frontend/lib/auth-db.ts
@@ -198,9 +198,47 @@ type ProfileInput = {
   email: string;
   name: string;
   grantSignupBonus?: boolean;
+  createDefaultApiKey?: boolean;
 };
 
 const SIGNUP_BONUS_CREDITS = 100;
+const DEFAULT_API_KEY_NAME = "Default";
+const API_KEY_PREFIX = "cerul_";
+const API_KEY_TOKEN_LENGTH = 32;
+const API_KEY_PREFIX_LENGTH = 16;
+
+const encoder = new TextEncoder();
+
+function asArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map((value) => value.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", asArrayBuffer(encoder.encode(value)));
+  return toHex(digest);
+}
+
+function randomHex(length: number): string {
+  const byteLength = Math.ceil(length / 2);
+  const buffer = new Uint8Array(byteLength);
+  crypto.getRandomValues(buffer);
+  return [...buffer].map((value) => value.toString(16).padStart(2, "0")).join("").slice(0, length);
+}
+
+async function generateApiKey(): Promise<{ rawKey: string; keyHash: string; prefix: string }> {
+  const token = randomHex(API_KEY_TOKEN_LENGTH);
+  const rawKey = `${API_KEY_PREFIX}${token}`;
+  const keyHash = await sha256Hex(rawKey);
+  return {
+    rawKey,
+    keyHash,
+    prefix: rawKey.slice(0, API_KEY_PREFIX_LENGTH),
+  };
+}
 
 export async function upsertUserProfile(profile: ProfileInput): Promise<void> {
   const displayName = profile.name.trim() || null;
@@ -219,60 +257,88 @@ export async function upsertUserProfile(profile: ProfileInput): Promise<void> {
       `.execute(trx);
 
       if (!profile.grantSignupBonus) {
+        if (!profile.createDefaultApiKey) {
+          return;
+        }
+      } else {
+        const insertedGrant = await sql<{ id: string }>`
+          INSERT INTO credit_grants (
+            user_id,
+            grant_key,
+            grant_type,
+            plan_code,
+            total_credits,
+            remaining_credits,
+            expires_at,
+            metadata
+          )
+          VALUES (
+            ${profile.id},
+            ${`signup_bonus:${profile.id}`},
+            'promo_bonus',
+            'free',
+            ${SIGNUP_BONUS_CREDITS},
+            ${SIGNUP_BONUS_CREDITS},
+            NULL,
+            ${JSON.stringify({ reason: "signup_bonus" })}::jsonb
+          )
+          ON CONFLICT (grant_key) DO NOTHING
+          RETURNING id
+        `.execute(trx);
+
+        const grantId = insertedGrant.rows[0]?.id;
+        if (grantId) {
+          await sql`
+            INSERT INTO credit_transactions (
+              user_id,
+              grant_id,
+              kind,
+              amount,
+              metadata
+            )
+            VALUES (
+              ${profile.id},
+              ${grantId}::uuid,
+              'grant',
+              ${SIGNUP_BONUS_CREDITS},
+              ${JSON.stringify({
+                grant_key: `signup_bonus:${profile.id}`,
+                grant_type: "promo_bonus",
+                reason: "signup_bonus",
+              })}::jsonb
+            )
+          `.execute(trx);
+        }
+      }
+
+      if (!profile.createDefaultApiKey) {
         return;
       }
 
-      const insertedGrant = await sql<{ id: string }>`
-        INSERT INTO credit_grants (
-          user_id,
-          grant_key,
-          grant_type,
-          plan_code,
-          total_credits,
-          remaining_credits,
-          expires_at,
-          metadata
-        )
-        VALUES (
-          ${profile.id},
-          ${`signup_bonus:${profile.id}`},
-          'promo_bonus',
-          'free',
-          ${SIGNUP_BONUS_CREDITS},
-          ${SIGNUP_BONUS_CREDITS},
-          NULL,
-          ${JSON.stringify({ reason: "signup_bonus" })}::jsonb
-        )
-        ON CONFLICT (grant_key) DO NOTHING
-        RETURNING id
-      `.execute(trx);
-
-      const grantId = insertedGrant.rows[0]?.id;
-      if (!grantId) {
-        return;
-      }
-
+      const generatedKey = await generateApiKey();
       await sql`
-        INSERT INTO credit_transactions (
+        INSERT INTO api_keys (
           user_id,
-          grant_id,
-          kind,
-          amount,
-          metadata
+          name,
+          key_hash,
+          prefix,
+          raw_key,
+          is_active
         )
-        VALUES (
+        SELECT
           ${profile.id},
-          ${grantId}::uuid,
-          'grant',
-          ${SIGNUP_BONUS_CREDITS},
-          ${JSON.stringify({
-            grant_key: `signup_bonus:${profile.id}`,
-            grant_type: "promo_bonus",
-            reason: "signup_bonus",
-          })}::jsonb
+          ${DEFAULT_API_KEY_NAME},
+          ${generatedKey.keyHash},
+          ${generatedKey.prefix},
+          ${generatedKey.rawKey},
+          TRUE
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM api_keys
+          WHERE user_id = ${profile.id}
+            AND is_active = TRUE
         )
       `.execute(trx);
-
     }),
   );
 }

--- a/frontend/lib/auth-server.test.ts
+++ b/frontend/lib/auth-server.test.ts
@@ -179,6 +179,7 @@ describe("getAuthRouteHandlers", () => {
       email: "owner@example.com",
       name: "Owner Example",
       grantSignupBonus: true,
+      createDefaultApiKey: true,
     });
     expect(state.sentEmails).toEqual([]);
 

--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -172,6 +172,7 @@ function createAuth() {
               email: user.email,
               name: user.name,
               grantSignupBonus: true,
+              createDefaultApiKey: true,
             });
 
             // Social signups can arrive already verified, so they should

--- a/frontend/lib/email-templates.test.ts
+++ b/frontend/lib/email-templates.test.ts
@@ -28,7 +28,8 @@ describe("email templates", () => {
     });
 
     expect(html).toContain("Welcome to Cerul, Owner Example!");
-    expect(html).toContain("1,000 free search requests");
+    expect(html).toContain("100 signup credits");
+    expect(html).toContain("300-credit monthly free tier");
     expect(html).toContain("https://cerul.ai/dashboard");
     expect(html).toContain("https://cerul.ai/docs");
   });

--- a/frontend/lib/email-templates.ts
+++ b/frontend/lib/email-templates.ts
@@ -224,8 +224,8 @@ export function welcomeTemplate(params: {
     title: `Welcome to Cerul, ${name}!`,
     intro: "Your account is ready.",
     body: [
-      "You now have 1,000 free search requests each month to try Cerul with your own workflows.",
-      "Create an API key from the dashboard whenever you are ready to connect an agent or internal tool.",
+      "You now have 100 signup credits and 10 free searches each day to start testing Cerul with your own workflows.",
+      "A default API key is ready in your dashboard, and you can add a payment method there whenever you want the 300-credit monthly free tier.",
       "The quickstart docs walk through the search API, dashboard basics, and how to get your first request live.",
     ],
     cta: {


### PR DESCRIPTION
## Summary
- lower free-tier monthly credits from 1,000 to 300 and gate free monthly grants on a stored payment-method flag
- split referral rewards into 100 credits for invitees and 200 credits for inviters, and auto-create a default API key at signup
- restore dashboard API key reveal/copy UX, update Playground SDK snippets/loading state, and align public-facing onboarding copy with the new credit model

## Affected directories
- `api/src/routes`
- `api/src/services`
- `frontend/app/docs`
- `frontend/components/dashboard`
- `frontend/lib`
- `db/migrations`

## Env vars / config
- No new env vars
- Added migration `021_credit_adjustments.sql` to update free-tier credit defaults, add `user_profiles.has_payment_method_on_file`, and restore `api_keys.raw_key`

## Testing
- `pnpm --dir frontend test`
- `pnpm --dir frontend lint`
- `npm --prefix api run check`

## Screenshots
- Not attached from the CLI run; UI changes are limited to API key reveal/copy controls and the Playground send button/snippet updates

## API examples
- `GET /dashboard/api-keys` now may return `raw_key` for masked reveal/copy in the dashboard
- `GET /dashboard/billing/catalog` now includes `invitee_bonus_credits: 100` and `inviter_bonus_credits: 200`
- Free-tier monthly credit grants remain at `0` until `has_payment_method_on_file` is true