### PR TITLE
Raise free tier API key limit to 2, unlimited for paid users

### DIFF
--- a/api/src/routes/dashboard.ts
+++ b/api/src/routes/dashboard.ts
@@ -700,10 +700,11 @@ export function createDashboardRouter(): any {
     }
 
     const tier = String(profile.tier ?? "free").toLowerCase();
+    const hasPaid = isPaidTier(tier) || Boolean(profile.has_payment_method_on_file);
     const activeKeyCount = await countActiveApiKeys(db, session.userId);
-    const keyLimit = keyLimitForTier(tier);
+    const keyLimit = hasPaid ? Infinity : keyLimitForTier(tier);
     if (activeKeyCount >= keyLimit) {
-      apiError(403, `${tier} tier allows at most ${keyLimit} active API key(s).`);
+      apiError(403, `Free tier allows at most ${keyLimit} active API key(s). Add a payment method to unlock unlimited keys.`);
     }
     if (!name) {
       apiError(422, "API key name must not be empty.");

--- a/api/src/services/billing.ts
+++ b/api/src/services/billing.ts
@@ -40,9 +40,9 @@ export const DEFAULT_MONTHLY_CREDIT_LIMITS: Record<string, number> = {
 };
 
 export const TIER_KEY_LIMITS: Record<string, number> = {
-  free: 1,
-  pro: 5,
-  enterprise: 25
+  free: 2,
+  pro: Infinity,
+  enterprise: Infinity
 };
 
 const PAID_TIERS = new Set(["pro", "enterprise"]);


### PR DESCRIPTION
## Summary
- Free tier API key limit: 1 → 2 (since default key is now auto-created at signup)
- Paid users (pro, enterprise, or any user with payment method on file): unlimited keys

## Test plan
- [ ] Free tier user can create up to 2 keys, gets error on 3rd
- [ ] User with payment method can create unlimited keys
- [ ] Pro/enterprise users can create unlimited keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)