### PR TITLE
Only return active API keys in dashboard listing

### DIFF
--- a/api/src/routes/dashboard.ts
+++ b/api/src/routes/dashboard.ts
@@ -356,7 +356,7 @@ async function listApiKeysForUser(db: DatabaseClient, userId: string): Promise<R
     `
       SELECT id, name, prefix, raw_key, created_at, last_used_at, is_active
       FROM api_keys
-      WHERE user_id = $1
+      WHERE user_id = $1 AND is_active = TRUE
       ORDER BY created_at DESC
     `,
     userId


### PR DESCRIPTION
## Summary
- Filter out revoked (`is_active = FALSE`) API keys from the dashboard listing endpoint
- Fixes bug where revoked keys were still displayed, causing `isLastKey` to miscalculate and disable the delete button on all keys

## Root cause
Key "123" for user panda@dubrify.com was already revoked (`is_active = false`) but still returned by the API. With 1 active + 1 revoked key displayed, `keys.filter(k => k.isActive).length <= 1` evaluated to `true`, disabling delete on both rows.

## Test plan
- [ ] Revoke a key → it disappears from the list
- [ ] With 2 active keys, delete button works on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)