### PR TITLE
docs: sync public API error subcodes from cerul-api

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -402,25 +402,68 @@ async function getUsage() {
 
 ## Error Handling
 
-The public API uses a stable JSON error envelope:
-
-| HTTP Status | `error.code` | Description |
-|-------------|--------------|-------------|
-| `400` | `invalid_request` | Invalid JSON body or request validation error |
-| `401` | `unauthorized` | Missing or invalid API key |
-| `403` | `forbidden` | Inactive API key or insufficient credits |
-| `404` | `not_found` | Route or resource not found |
-| `422` | `invalid_request` | Payload is syntactically valid but semantically invalid |
-| `429` | `rate_limited` | Rate limit exceeded |
-| `500+` | `api_error` | Unexpected server error |
-
-Error response format:
+The public API uses a stable JSON error envelope. Every `/v1` error response
+carries an `error.code` (coarse category) plus an optional `error.subcode`
+(fine-grained reason) and a `request_id` that matches the `x-request-id`
+response header.
 
 ```json
 {
   "error": {
-    "code": "invalid_request",
-    "message": "Unsupported URL format"
+    "code": "forbidden",
+    "subcode": "insufficient_credits",
+    "message": "Insufficient credits for this request",
+    "request_id": "req_9f8c1d5b2a9f7d1a8c4e6b02"
   }
 }
 ```
+
+**Branch on `error.subcode ?? error.code`.** This keeps older clients that
+only understand `error.code` working, while giving newer clients and agents a
+stable fine-grained key.
+
+### Coarse codes
+
+| HTTP | `error.code` | When |
+|---|---|---|
+| `400` | `invalid_request` | Generic schema or request validation failure |
+| `401` | `unauthorized` | Missing or invalid credentials — see auth subcodes |
+| `403` | `forbidden` | Key inactive, billing hold, or insufficient credits |
+| `404` | `not_found` | Unknown `/v1/*` path |
+| `422` | `invalid_request` | Payload accepted but semantically invalid (e.g. `invalid_image`) |
+| `429` | `rate_limited` | Rate limit exceeded — honor `Retry-After` |
+| `500` | `internal_error` | Unhandled internal failure — retry with bounded backoff |
+
+### Subcodes
+
+| `subcode` | Coarse | HTTP | Trigger | Recommended action |
+|---|---|---|---|---|
+| `missing_authorization` | `unauthorized` | `401` | No `Authorization` header on `/v1/*` | Add `Authorization: Bearer cerul_...` and retry |
+| `invalid_authorization_header` | `unauthorized` | `401` | Non-Bearer or empty Bearer | Fix the header format before retrying |
+| `malformed_api_key` | `unauthorized` | `401` | API key fails format validation | Check the copy/paste and prefix |
+| `invalid_api_key` | `unauthorized` | `401` | Key format OK, key unknown | Regenerate the key in the dashboard |
+| `api_key_inactive` | `forbidden` | `403` | Key was revoked or deactivated | Regenerate or reactivate the key |
+| `billing_hold` | `forbidden` | `403` | Account is under billing review | Contact support; do not retry |
+| `insufficient_credits` | `forbidden` | `403` | Wallet balance below request cost | Call `GET /v1/usage`, show remaining balance, prompt top-up |
+| `rate_limit_exceeded` | `rate_limited` | `429` | Per-key rate limit exceeded | Wait `Retry-After` seconds plus jitter, then retry |
+| `invalid_image` | `invalid_request` | `422` | Search image can't be decoded, downloaded, or is unsupported | Fix the image input; text-only search can still work |
+
+### Response headers
+
+- `x-request-id` — opaque request identifier. Always echoed; include it in
+  support tickets and client logs.
+- `www-authenticate: Bearer` — sent on `401` responses.
+- `retry-after` — sent on `429` responses. Integer seconds.
+
+### Recommended client behavior
+
+1. Compute `branchKey = error.subcode ?? error.code`.
+2. Persist `error.request_id` and the `x-request-id` header in logs.
+3. Only auto-retry `rate_limit_exceeded`, `rate_limited`, and `internal_error`.
+4. For auth and billing failures, stop retrying and surface the problem.
+5. For `invalid_request` and `invalid_image`, repair the request before retrying.
+
+The full machine-readable reference lives in
+[`public-api-errors.md`](./public-api-errors.md), and the endpoint-level
+contract is in [`openapi.yaml`](../openapi.yaml) (kept in sync with
+`cerul-api`).

--- a/docs/public-api-errors.md
+++ b/docs/public-api-errors.md
@@ -1,0 +1,100 @@
+# Public API Error Reference
+
+This file is the source copy for public error-handling docs. Publish it alongside `openapi.yaml` so users and agents can self-diagnose failed API calls.
+
+## Response shape
+
+All public `/v1` errors use the same JSON envelope:
+
+```json
+{
+  "error": {
+    "code": "forbidden",
+    "subcode": "insufficient_credits",
+    "message": "Insufficient credits for this request",
+    "request_id": "req_9f8c1d5b2a9f7d1a8c4e6b02"
+  }
+}
+```
+
+`error.subcode` is optional. For machine branching, prefer `error.subcode` when present and fall back to `error.code` otherwise.
+
+Public `/v1` responses also include an `x-request-id` header. Use that value in logs and support tickets. Authentication failures include `WWW-Authenticate: Bearer`, and rate limits include `Retry-After`.
+
+## Machine branch key
+
+Use:
+
+```text
+error.subcode ?? error.code
+```
+
+This preserves backward compatibility for existing clients that only know the coarse `error.code`, while giving newer clients and agents a stable fine-grained key.
+
+## Subcodes
+
+### auth
+
+| subcode | coarse code | HTTP | trigger | agent action |
+| --- | --- | --- | --- | --- |
+| `missing_authorization` | `unauthorized` | `401` | No `Authorization` header on a `/v1/*` request | Add `Authorization: Bearer cerul_...` and retry |
+| `invalid_authorization_header` | `unauthorized` | `401` | Malformed authorization header, including non-Bearer or empty Bearer token | Fix the header format before retrying |
+| `malformed_api_key` | `unauthorized` | `401` | API key fails format validation | Check the key copy/paste and prefix |
+| `invalid_api_key` | `unauthorized` | `401` | API key format passes but the key is unknown | Regenerate the key in the dashboard |
+| `api_key_inactive` | `forbidden` | `403` | API key was revoked or deactivated | Regenerate or reactivate the key |
+
+### billing
+
+| subcode | coarse code | HTTP | trigger | agent action |
+| --- | --- | --- | --- | --- |
+| `billing_hold` | `forbidden` | `403` | Account is under billing review | Surface the problem to the human user and contact support |
+| `insufficient_credits` | `forbidden` | `403` | Wallet balance is below request cost | Call `GET /v1/usage`, show the remaining balance, and ask the user to top up |
+
+### rate limit
+
+| subcode | coarse code | HTTP | trigger | agent action |
+| --- | --- | --- | --- | --- |
+| `rate_limit_exceeded` | `rate_limited` | `429` | Request rate exceeded the current account/key limit | Wait `Retry-After` seconds plus jitter, then retry |
+
+### invalid request
+
+| subcode | coarse code | HTTP | trigger | agent action |
+| --- | --- | --- | --- | --- |
+| `invalid_image` | `invalid_request` | `422` | Search image could not be decoded, downloaded, or is unsupported | Fix the image input; text-only search can still work |
+
+## Coarse-only responses
+
+These responses currently do not emit a dedicated `subcode`.
+
+| code | HTTP | when | agent action |
+| --- | --- | --- | --- |
+| `invalid_request` | `400` | Generic schema or validation failure | Fix the request body and do not retry unchanged |
+| `not_found` | `404` | Unknown `/v1/*` path or a future resource miss | Verify the path or identifier before retrying |
+| `internal_error` | `500` | Unhandled internal failure | Retry with bounded exponential backoff and include `request_id` if it repeats |
+
+## Endpoint matrix
+
+| Endpoint | Success | Coarse codes | Possible subcodes |
+| --- | --- | --- | --- |
+| `POST /v1/search` | `200` | `invalid_request`, `unauthorized`, `forbidden`, `rate_limited`, `internal_error` | `missing_authorization`, `invalid_authorization_header`, `malformed_api_key`, `invalid_api_key`, `api_key_inactive`, `billing_hold`, `insufficient_credits`, `rate_limit_exceeded`, `invalid_image` |
+| `GET /v1/usage` | `200` | `unauthorized`, `forbidden`, `rate_limited`, `internal_error` | `missing_authorization`, `invalid_authorization_header`, `malformed_api_key`, `invalid_api_key`, `api_key_inactive`, `billing_hold`, `rate_limit_exceeded` |
+| Any unknown `/v1/*` path | none | `not_found` | none |
+
+## Search-specific `invalid_image` examples
+
+- `Unsupported image type: image/gif`
+- `Invalid base64 image payload`
+- `Failed to download image: 404`
+- `Image too large: 12582912 bytes (max 10485760)`
+
+## Recommended agent behavior
+
+1. Compute a branch key as `error.subcode ?? error.code`.
+2. Persist `error.request_id` and the `x-request-id` header in logs.
+3. Only auto-retry `rate_limit_exceeded`, `rate_limited`, and `internal_error`.
+4. For auth and billing failures, stop retrying and ask for corrected credentials or human action.
+5. For `invalid_request` and `invalid_image`, repair the request before retrying.
+
+## Publishing note
+
+This repository already treats `openapi.yaml` as the API contract source of truth. Keep this error reference aligned with the OpenAPI file and publish both to the public docs surface instead of maintaining a separate runtime-only error catalog endpoint.

--- a/frontend/app/docs/search-api/page.tsx
+++ b/frontend/app/docs/search-api/page.tsx
@@ -90,13 +90,28 @@ const responseFields = [
   { name: "request_id", type: "string", description: "Unique request identifier in the form req_<24-hex-chars>." },
 ];
 
-const errors = [
-  { status: "400", code: "invalid_request", description: "Invalid JSON body or request validation error." },
-  { status: "401", code: "unauthorized", description: "Missing or invalid API key." },
-  { status: "403", code: "forbidden", description: "Inactive API key, billing hold, or insufficient credits." },
-  { status: "404", code: "not_found", description: "Route or resource not found." },
-  { status: "429", code: "rate_limited", description: "Rate limit exceeded. Retry after the limit resets." },
-  { status: "500+", code: "api_error", description: "Internal server error." },
+type ErrorRow = {
+  status: string;
+  code: string;
+  subcode?: string;
+  description: string;
+};
+
+// Public error contract. Keep in sync with openapi.yaml and docs/public-api-errors.md.
+// Clients should branch on `error.subcode ?? error.code`.
+const errors: ErrorRow[] = [
+  { status: "400", code: "invalid_request", description: "Generic schema or request validation failure — fix the body and do not retry unchanged." },
+  { status: "401", code: "unauthorized", subcode: "missing_authorization", description: "No Authorization header on /v1/*. Add Authorization: Bearer cerul_... and retry." },
+  { status: "401", code: "unauthorized", subcode: "invalid_authorization_header", description: "Authorization header is not a Bearer token (wrong scheme or empty Bearer)." },
+  { status: "401", code: "unauthorized", subcode: "malformed_api_key", description: "API key fails format validation. Check copy/paste and the cerul_ prefix." },
+  { status: "401", code: "unauthorized", subcode: "invalid_api_key", description: "Key format is valid but the key is unknown. Regenerate it in the dashboard." },
+  { status: "403", code: "forbidden", subcode: "api_key_inactive", description: "API key was revoked or deactivated. Regenerate or reactivate the key." },
+  { status: "403", code: "forbidden", subcode: "billing_hold", description: "Account is under billing review. Contact support; do not auto-retry." },
+  { status: "403", code: "forbidden", subcode: "insufficient_credits", description: "Wallet balance is below request cost. Check GET /v1/usage and prompt for top-up." },
+  { status: "404", code: "not_found", description: "Unknown /v1/* path or resource." },
+  { status: "422", code: "invalid_request", subcode: "invalid_image", description: "Search image could not be decoded, downloaded, or is unsupported. Text-only search still works." },
+  { status: "429", code: "rate_limited", subcode: "rate_limit_exceeded", description: "Per-key rate limit exceeded. Honor Retry-After plus jitter before retrying." },
+  { status: "500", code: "internal_error", description: "Unhandled internal failure. Retry with bounded exponential backoff and include request_id if it repeats." },
 ];
 
 export default function SearchApiPage() {
@@ -461,23 +476,57 @@ console.log(data);`}
                   </h2>
                 </FadeIn>
 
+                <p className="mt-4 max-w-4xl text-[15px] leading-8 text-[var(--foreground-secondary)]">
+                  Every /v1 error response carries an <code className="font-mono">error.code</code>{" "}
+                  (coarse category) plus an optional <code className="font-mono">error.subcode</code>{" "}
+                  (fine-grained reason), a human-readable{" "}
+                  <code className="font-mono">error.message</code>, and a{" "}
+                  <code className="font-mono">request_id</code> that matches the{" "}
+                  <code className="font-mono">x-request-id</code> response header. Clients and
+                  agents should branch on{" "}
+                  <code className="font-mono">error.subcode ?? error.code</code> — this preserves
+                  backward compatibility for callers that only understand the coarse code.
+                </p>
+
+                <div className="mt-6">
+                  <CodeBlock
+                    code={`{
+  "error": {
+    "code": "forbidden",
+    "subcode": "insufficient_credits",
+    "message": "Insufficient credits for this request",
+    "request_id": "req_9f8c1d5b2a9f7d1a8c4e6b02"
+  }
+}`}
+                    language="json"
+                    filename="error-envelope.json"
+                  />
+                </div>
+
                 <div className="mt-6 overflow-hidden rounded-[20px] border border-[var(--border)]">
                   <table className="w-full text-left text-sm">
                     <thead className="bg-[var(--background-elevated)] text-[var(--foreground-secondary)]">
                       <tr>
                         <th className="px-4 py-3 font-medium">Status</th>
                         <th className="px-4 py-3 font-medium">Code</th>
+                        <th className="px-4 py-3 font-medium">Subcode</th>
                         <th className="px-4 py-3 font-medium">Description</th>
                       </tr>
                     </thead>
                     <tbody className="bg-white/65">
                       {errors.map((error) => (
-                        <tr key={`${error.status}-${error.code}`} className="border-t border-[var(--border)]">
+                        <tr
+                          key={`${error.status}-${error.code}-${error.subcode ?? "none"}`}
+                          className="border-t border-[var(--border)]"
+                        >
                           <td className="px-4 py-4 font-mono text-[var(--foreground)]">
                             {error.status}
                           </td>
                           <td className="px-4 py-4 font-mono text-[var(--foreground-secondary)]">
                             {error.code}
+                          </td>
+                          <td className="px-4 py-4 font-mono text-[var(--foreground-secondary)]">
+                            {error.subcode ?? "—"}
                           </td>
                           <td className="px-4 py-4 text-[var(--foreground-secondary)]">
                             {error.description}
@@ -487,6 +536,15 @@ console.log(data);`}
                     </tbody>
                   </table>
                 </div>
+
+                <p className="mt-5 max-w-4xl text-sm leading-7 text-[var(--foreground-secondary)]">
+                  Only auto-retry <code className="font-mono">rate_limit_exceeded</code>,{" "}
+                  <code className="font-mono">rate_limited</code>, and{" "}
+                  <code className="font-mono">internal_error</code>. For auth, billing, and
+                  invalid-request failures, stop retrying and surface the problem.{" "}
+                  <code className="font-mono">429</code> responses include a{" "}
+                  <code className="font-mono">Retry-After</code> header in seconds.
+                </p>
 
                 <div className="mt-8 flex flex-wrap gap-3">
                   <Link href="/docs" className="button-secondary">

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -576,7 +576,6 @@ components:
                 - not_found
                 - rate_limited
                 - internal_error
-                - api_error
               description: Machine-readable coarse error code.
             subcode:
               type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,6 +5,9 @@ info:
   description: |
     Video understanding search API for AI agents.
     Search across indexed videos by meaning — visual scenes, speech, and on-screen text.
+
+    Public `/v1` responses include an `x-request-id` header. Public errors use
+    a stable envelope: `{ "error": { "code", "subcode?", "message", "request_id?" } }`.
   contact:
     name: Cerul
     url: https://cerul.ai
@@ -38,7 +41,8 @@ paths:
         results with relevance scores and source URLs.
 
         Each search costs 1 credit, or 2 credits when `include_answer` is true.
-        Image search is not part of the first public contract.
+        Search requests may include text, an image, or both. Invalid image
+        inputs return `422`.
       requestBody:
         required: true
         content:
@@ -63,9 +67,28 @@ paths:
                     min_duration: 60
                     max_duration: 7200
                     source: youtube
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/SearchMultipartRequest"
+            encoding:
+              filters:
+                contentType: application/json
+            examples:
+              imageUpload:
+                summary: Multipart search with image upload
+                value:
+                  query: red race car drifting around a corner
+                  image_file: <binary image payload>
+                  max_results: 5
+                  include_answer: false
+                  ranking_mode: embedding
+                  filters: "{\"source\":\"youtube\"}"
       responses:
         "200":
           description: Search results
+          headers:
+            x-request-id:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -132,6 +155,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -149,6 +174,9 @@ paths:
       responses:
         "200":
           description: Usage information
+          headers:
+            x-request-id:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -182,26 +210,38 @@ paths:
           $ref: "#/components/responses/InternalError"
 
 components:
+  headers:
+    XRequestId:
+      description: Request identifier for tracing and support.
+      schema:
+        type: string
+        pattern: ^req_[0-9a-f]{24}$
+
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       description: |
-        Cerul API key. Pass as `Authorization: Bearer cerul_sk_...`.
+        Cerul API key. Pass as `Authorization: Bearer cerul_...`.
         Create and manage keys from the [dashboard](https://cerul.ai/dashboard).
 
   schemas:
     SearchRequest:
       type: object
       additionalProperties: false
-      required:
-        - query
+      anyOf:
+        - required:
+            - query
+        - required:
+            - image
       properties:
         query:
           type: string
           maxLength: 400
           pattern: \S
           description: Natural language search query. Must contain at least one non-whitespace character.
+        image:
+          $ref: "#/components/schemas/SearchImageInput"
         max_results:
           type: integer
           minimum: 1
@@ -224,6 +264,59 @@ components:
             Costs 2 credits instead of 1.
         filters:
           $ref: "#/components/schemas/SearchFilters"
+
+    SearchMultipartRequest:
+      type: object
+      additionalProperties: false
+      anyOf:
+        - required:
+            - query
+        - required:
+            - image_file
+      properties:
+        query:
+          type: string
+          maxLength: 400
+          pattern: \S
+          description: Natural language search query.
+        image_file:
+          type: string
+          format: binary
+          description: JPEG, PNG, or WebP image up to 10 MB.
+        max_results:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 10
+        ranking_mode:
+          type: string
+          enum:
+            - embedding
+            - rerank
+          default: embedding
+        include_answer:
+          type: boolean
+          default: false
+        filters:
+          type: string
+          description: JSON-encoded object that matches `SearchFilters`.
+
+    SearchImageInput:
+      type: object
+      additionalProperties: false
+      oneOf:
+        - required:
+            - url
+        - required:
+            - base64
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Publicly reachable image URL.
+        base64:
+          type: string
+          description: Raw base64 image payload or a `data:` URI.
 
     SearchFilters:
       type: object
@@ -482,15 +575,36 @@ components:
                 - forbidden
                 - not_found
                 - rate_limited
+                - internal_error
                 - api_error
-              description: Machine-readable error code.
+              description: Machine-readable coarse error code.
+            subcode:
+              type: string
+              enum:
+                - missing_authorization
+                - invalid_authorization_header
+                - malformed_api_key
+                - invalid_api_key
+                - api_key_inactive
+                - billing_hold
+                - insufficient_credits
+                - rate_limit_exceeded
+                - invalid_image
+              description: Optional fine-grained machine-readable error code. Prefer `subcode` over `code` when present.
             message:
               type: string
               description: Human-readable error message.
+            request_id:
+              type: string
+              pattern: ^req_[0-9a-f]{24}$
+              description: Unique request identifier for debugging and support.
 
   responses:
     BadRequest:
       description: Invalid request body or missing required field.
+      headers:
+        x-request-id:
+          $ref: "#/components/headers/XRequestId"
       content:
         application/json:
           schema:
@@ -524,6 +638,8 @@ components:
     Unauthorized:
       description: Missing or invalid API key.
       headers:
+        x-request-id:
+          $ref: "#/components/headers/XRequestId"
         WWW-Authenticate:
           schema:
             type: string
@@ -538,28 +654,35 @@ components:
               value:
                 error:
                   code: unauthorized
-                  message: Missing Authorization header.
-            invalidBearerScheme:
-              summary: Authorization header must use Bearer
+                  subcode: missing_authorization
+                  message: Missing Authorization header
+            invalidAuthorizationHeader:
+              summary: Authorization header is malformed
               value:
                 error:
                   code: unauthorized
-                  message: Authorization header must use the Bearer scheme.
+                  subcode: invalid_authorization_header
+                  message: Authorization header must use the Bearer scheme
             malformedApiKey:
               summary: API key format is invalid
               value:
                 error:
                   code: unauthorized
-                  message: Malformed API key.
+                  subcode: malformed_api_key
+                  message: Malformed API key
             invalidApiKey:
               summary: API key not recognized
               value:
                 error:
                   code: unauthorized
+                  subcode: invalid_api_key
                   message: Invalid API key
 
     Forbidden:
       description: Inactive API key or insufficient credits.
+      headers:
+        x-request-id:
+          $ref: "#/components/headers/XRequestId"
       content:
         application/json:
           schema:
@@ -570,23 +693,60 @@ components:
               value:
                 error:
                   code: forbidden
+                  subcode: api_key_inactive
                   message: API key is inactive
             billingHold:
               summary: Billing account requires review
               value:
                 error:
                   code: forbidden
-                  message: Billing account requires review before more requests can be served.
+                  subcode: billing_hold
+                  message: Billing account requires review before more requests can be served
             requestCreditsInsufficient:
               summary: Insufficient credits for this request
               value:
                 error:
                   code: forbidden
+                  subcode: insufficient_credits
                   message: Insufficient credits for this request
+
+    UnprocessableEntity:
+      description: Request payload is syntactically valid but contains an invalid search image.
+      headers:
+        x-request-id:
+          $ref: "#/components/headers/XRequestId"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            unsupportedImageType:
+              summary: Uploaded image type is not supported
+              value:
+                error:
+                  code: invalid_request
+                  subcode: invalid_image
+                  message: "Unsupported image type: image/gif"
+            invalidBase64:
+              summary: Base64 payload cannot be decoded
+              value:
+                error:
+                  code: invalid_request
+                  subcode: invalid_image
+                  message: Invalid base64 image payload
+            downloadFailed:
+              summary: Remote image URL could not be fetched
+              value:
+                error:
+                  code: invalid_request
+                  subcode: invalid_image
+                  message: "Failed to download image: 404"
 
     RateLimited:
       description: Rate limit exceeded.
       headers:
+        x-request-id:
+          $ref: "#/components/headers/XRequestId"
         Retry-After:
           schema:
             type: integer
@@ -599,15 +759,19 @@ components:
           example:
             error:
               code: rate_limited
+              subcode: rate_limit_exceeded
               message: Rate limit exceeded
 
     InternalError:
       description: Unexpected server error.
+      headers:
+        x-request-id:
+          $ref: "#/components/headers/XRequestId"
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           example:
             error:
-              code: api_error
+              code: internal_error
               message: Internal server error


### PR DESCRIPTION
## Summary

- Sync `openapi.yaml` from cerul-api (adds `ErrorEnvelope.subcode` field and per-endpoint subcode matrix — 613 → 777 lines)
- Add `docs/public-api-errors.md` as a verbatim mirror of `cerul-api/PUBLIC_API_ERRORS.md` — the canonical reference for agents and SDK consumers
- Rewrite the Error Handling section in `docs/api-reference.md` to describe the coarse+subcode envelope, list all 9 subcodes with triggers and recommended actions, and spell out the retry policy
- Rewrite the rendered error table in `frontend/app/docs/search-api/page.tsx` — the actual page at https://cerul.ai/docs/search-api — to show the full 12-variant contract with a Subcode column, an example error envelope, and the `error.subcode ?? error.code` branching rule

## Context

cerul-ai/cerul-api#12 landed a public error-handling contract with fine-grained subcodes (`missing_authorization`, `malformed_api_key`, `invalid_api_key`, `api_key_inactive`, `billing_hold`, `insufficient_credits`, `rate_limit_exceeded`, `invalid_image`). The source of truth is maintained in `cerul-api/openapi.yaml` and `cerul-api/PUBLIC_API_ERRORS.md`, but the published copies in this repo drifted. Before this PR, https://cerul.ai/docs/search-api showed:

- Only 6 coarse codes, no subcodes
- No mention of `error.subcode` or the `error.subcode ?? error.code` branching rule
- The typo `api_error` where the API actually returns `internal_error` (verified against prod)

Verified subcode behavior against prod https://api.cerul.ai/v1/search while debugging this:

| Curl | Observed response |
|---|---|
| no Authorization | `401 unauthorized / missing_authorization` |
| `Bearer sk_wrong` | `401 unauthorized / malformed_api_key` |
| `Bearer cerul_<unknown>` | `401 unauthorized / invalid_api_key` |
| `{"image":{"base64":"not-real-!!!"}}` | `422 invalid_request / invalid_image` |
| `{"query":"$(x*500)"}` | `400 invalid_request` |

## Test plan

- [x] `tsc --noEmit` on frontend — clean
- [x] `eslint frontend/app/docs/search-api/page.tsx` — clean
- [ ] Reviewer: preview `/docs/search-api` on the deploy preview and confirm the new Errors section renders (subcode column, envelope example, branching paragraph, retry policy paragraph)
- [ ] Reviewer: confirm the renderered HTML on `/docs/api-reference.md` (root markdown) still builds if that file is picked up by any static pipeline

## Out of scope

- No runtime behavior changes; this is a docs + spec sync.
- `frontend/app/docs/api-reference/page.tsx` is not touched — it renders from `apiReferenceEndpoints` in `lib/docs.ts` and has no error section. A future PR could either (a) extend `ApiReferenceEndpoint` with per-endpoint error data, or (b) introduce an automatic Redoc/Scalar render of `openapi.yaml` so we stop hand-maintaining these tables in two places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)