### PR TITLE
Fix public and console responsive layouts

### DIFF
--- a/MOBILE_RESPONSIVE_FIXES.md
+++ b/MOBILE_RESPONSIVE_FIXES.md
@@ -1,0 +1,743 @@
+# Cerul Mobile Responsive Audit and Remediation Plan
+
+> Audit date: 2026-04-13
+> Scope: `frontend/` public pages, docs pages, dashboard shell, admin shell
+> Verification method: code inspection + live mobile rendering in iPhone 14 emulation
+
+## Executive Summary
+
+The statement "mobile adaptation is very poor across pages" is directionally true, but not evenly true for every page.
+
+What is clearly true after verification:
+
+- The docs page family has real mobile layout problems, including severe horizontal overflow.
+- Dashboard and admin lose primary navigation on smaller screens.
+- The homepage has horizontal overflow on mobile and needs containment fixes.
+
+What is not fully true, or is already stale in the previous version of this document:
+
+- The missing `viewport` export in `frontend/app/layout.tsx` is not proven to be the root cause.
+- `DocsSidebar` already has a mobile toggle and should not be treated as "missing mobile navigation".
+- The auth shell is not currently a priority mobile breakage based on live rendering.
+- `pricing` and `brand` can be improved, but they are not in the same severity class as the docs pages.
+
+The practical goal should be:
+
+1. Fix mobile-only breakages first.
+2. Keep all desktop layouts visually unchanged.
+3. Avoid broad global CSS band-aids that hide the real overflow sources.
+
+---
+
+## Audit Method
+
+I verified the current state in two ways:
+
+1. Read the actual layout and shell code in `frontend/app` and `frontend/components`.
+2. Ran the app locally and captured full-page screenshots in iPhone 14 emulation.
+
+Baseline note:
+
+- In iPhone 14 emulation, a normal page screenshot is roughly `1170px` wide because the device viewport is `390 CSS px` with a device pixel ratio of `3`.
+- Pages significantly wider than that are genuinely overflowing horizontally.
+
+Measured results:
+
+| Page | Screenshot width | Result |
+| --- | ---: | --- |
+| `/login` | 1170 | Normal baseline, no major layout break observed |
+| `/pricing` | 1179 | Close to baseline, readable but table UX is dense |
+| `/brand` | 1179 | Close to baseline, no major overflow detected |
+| `/` | 1602 | Horizontal overflow confirmed |
+| `/docs` | 4080 | Severe horizontal overflow confirmed |
+| `/docs/api-reference` | 5064 | Severe horizontal overflow confirmed |
+| `/docs/search-api` | 4962 | Severe horizontal overflow confirmed |
+
+This means the problem is real, but concentrated in a few important layout systems rather than every page equally.
+
+---
+
+## Verified Findings
+
+### P0 — Real Mobile Breakages
+
+#### 1. Dashboard loses primary navigation on mobile
+
+Evidence:
+
+- `frontend/components/dashboard/dashboard-sidebar.tsx:82`
+- The sidebar is `hidden ... lg:block`.
+- `frontend/components/dashboard/dashboard-app-shell.tsx` does not render a mobile replacement.
+- `frontend/components/dashboard/dashboard-top-nav.tsx` only renders utility actions, not route navigation.
+
+Why this matters:
+
+- On screens below `lg`, users can land inside dashboard pages but cannot reliably move between them.
+- This is a true functional break, not just a visual issue.
+
+Required fix:
+
+- Add a dedicated mobile drawer or sheet navigation for dashboard routes.
+- Reuse `dashboardRoutes`.
+- Mount it in the top bar or app shell for `< lg`.
+- Keep the desktop sidebar untouched.
+
+Desktop safety rule:
+
+- New component must be `lg:hidden`.
+- Existing sidebar stays exactly as-is with `lg:block`.
+
+---
+
+#### 2. Admin loses primary navigation on mobile and tablet-width screens
+
+Evidence:
+
+- `frontend/components/admin/admin-sidebar.tsx:135`
+- The sidebar is `hidden ... xl:block`.
+- `frontend/components/admin/admin-app-shell.tsx` has no mobile fallback.
+- `frontend/components/admin/admin-top-bar.tsx` renders utility actions only.
+
+Why this matters:
+
+- This is even more restrictive than dashboard because the admin sidebar disappears below `xl`, not just below `lg`.
+- iPad-sized layouts are affected too.
+
+Required fix:
+
+- Add `admin-mobile-nav.tsx` using the same route config as the desktop sidebar.
+- Mount it in the admin top bar for `< xl`.
+
+Desktop safety rule:
+
+- Mobile nav only appears under `xl:hidden`.
+- Existing `xl:block` sidebar stays intact.
+
+---
+
+#### 3. Docs layout family has severe horizontal overflow on mobile
+
+Evidence:
+
+- Live rendering confirms major overflow on:
+  - `/docs`
+  - `/docs/api-reference`
+  - `/docs/search-api`
+- Shared desktop-style layout patterns still present in:
+  - `frontend/app/docs/page.tsx:39`
+  - `frontend/app/docs/api-reference/page.tsx:57`
+  - `frontend/app/docs/search-api/page.tsx:123`
+- `DocsToc` is always rendered as a sticky card:
+  - `frontend/components/docs-toc.tsx:64`
+
+Why this matters:
+
+- This is the clearest proof that the current docs mobile experience is genuinely broken.
+- The issue is systemic to the docs layout family, not isolated to one page.
+
+Likely contributing causes:
+
+- Three-column desktop composition collapses visually, but some inner blocks still behave like desktop content.
+- Sticky TOC and wide content blocks remain in the flow without a dedicated mobile presentation.
+- Code blocks and tables are contained locally with `overflow-x-auto`, but the surrounding page-level composition still leaks width.
+
+Required fix:
+
+- Treat docs as a layout-system fix, not as isolated page tweaks.
+- Add a dedicated mobile docs pattern:
+  - mobile docs navigation trigger
+  - mobile TOC trigger or collapsible section
+  - mobile-safe content wrappers around code and tables
+
+Desktop safety rule:
+
+- Preserve existing `lg:grid-cols[...]` layouts for desktop.
+- Add mobile-only wrappers or alternatives rather than rewriting the desktop structure.
+
+---
+
+#### 4. API Reference page has no real mobile nav replacement
+
+Evidence:
+
+- `frontend/app/docs/api-reference/page.tsx:58`
+- The left nav is an inline `aside`, not the shared `DocsSidebar`.
+- Unlike `DocsSidebar`, this page has no mobile toggle.
+
+Why this matters:
+
+- Even if general docs navigation is improved, this page still has its own unique mobile blocker.
+- It should not be grouped together with the "DocsSidebar is missing" claim, because that claim is stale.
+
+Required fix:
+
+- Extract the API reference sidebar into a reusable component with:
+  - desktop sticky sidebar
+  - mobile collapsible panel or drawer
+
+Desktop safety rule:
+
+- Desktop API reference sidebar remains the default on `lg` and above.
+
+---
+
+### P1 — Important UX and Layout Problems
+
+#### 5. Homepage still overflows horizontally on mobile
+
+Evidence:
+
+- Live rendering of `/` produced a width of `1602px`, above the mobile baseline.
+- The demo block and its surrounding animated/visual wrappers are the most likely overflow candidates:
+  - `frontend/app/page.tsx:178`
+  - `frontend/app/page.tsx:193`
+  - `frontend/components/animations.tsx:51-77`
+
+Why this matters:
+
+- This affects the first public page users see.
+- Even moderate overflow makes the page feel unstable on phones.
+
+Likely contributing causes:
+
+- Wide demo content inside a two-column marketing section.
+- Animated wrappers using `transform` before visibility settles.
+- Decorative visual layers making the page canvas wider than intended.
+
+Required fix:
+
+- Audit homepage sections for `min-w-0`, `max-w-full`, and overflow containment.
+- Constrain code/demo containers explicitly on small screens.
+- If needed, reduce only mobile spacing and chip density.
+
+Desktop safety rule:
+
+- Do not change `lg:grid-cols-2`.
+- Apply containment and spacing fixes only below `lg`.
+
+---
+
+#### 6. Docs TOC and docs tabs are not truly mobile-friendly
+
+Evidence:
+
+- `DocsToc` is always rendered on docs pages:
+  - `frontend/app/docs/page.tsx:312`
+  - `frontend/app/docs/api-reference/page.tsx:345`
+  - `frontend/app/docs/search-api/page.tsx:564`
+- `frontend/components/docs-header.tsx:118-126` uses horizontally scrollable tabs with `whitespace-nowrap`.
+
+What is true here:
+
+- The docs header tabs are not missing a mobile state; they do scroll.
+- But the current experience is still rough on mobile:
+  - tab labels can truncate visually
+  - scroll affordance is weak
+  - TOC is not transformed into a mobile-first pattern
+
+Required fix:
+
+- Keep horizontal tab scroll, but add visual affordance such as fade edges or a stronger active-state cue.
+- Hide the sticky TOC card below `lg`.
+- Replace it with an inline collapsible "On this page" section or a floating button that opens a sheet.
+
+Desktop safety rule:
+
+- Desktop sticky TOC remains unchanged on `lg+`.
+- Mobile gets a separate rendering path.
+
+---
+
+#### 7. Full-width data tables in docs should not rely on raw horizontal scroll alone
+
+Evidence:
+
+- Pricing comparison table:
+  - `frontend/app/pricing/page.tsx:161-163`
+- API reference parameter table:
+  - `frontend/app/docs/api-reference/page.tsx` parameter tables in the main content
+- Search API page error/code tables:
+  - `frontend/app/docs/search-api/page.tsx:514+`
+
+What is true here:
+
+- `overflow-x-auto` prevents the layout from fully collapsing in some places.
+- But on mobile, that is still a weak UX for dense structured data.
+
+Required fix:
+
+- Keep tables on desktop.
+- Introduce card or definition-list renderers on mobile for the densest tables.
+- Use horizontal scroll only as a fallback, not as the primary mobile design.
+
+Desktop safety rule:
+
+- Use `hidden lg:block` and `lg:hidden` pairings rather than altering the existing desktop tables.
+
+---
+
+### P2 — Secondary Issues Worth Fixing
+
+#### 8. Dashboard top nav hides current page context on mobile
+
+Evidence:
+
+- `frontend/components/dashboard/dashboard-top-nav.tsx:23`
+- Breadcrumb area is `hidden md:flex`.
+
+Impact:
+
+- Users on phones lose page context even after navigation is fixed.
+
+Recommended fix:
+
+- Show the active page label next to the mobile menu button on `< md`.
+
+---
+
+#### 9. Public site header hides GitHub on mobile
+
+Evidence:
+
+- `frontend/components/site-header.tsx:47-57`
+- GitHub action is `hidden ... lg:inline-flex`.
+
+Impact:
+
+- This is not a structural break, but it removes an important public action on small screens.
+
+Recommended fix:
+
+- Add a compact icon-only GitHub action for mobile.
+- Or include GitHub as an item in the mobile nav/action row.
+
+---
+
+#### 10. Animation-first rendering can worsen perceived mobile instability
+
+Evidence:
+
+- `frontend/components/animations.tsx:29-77`
+- `FadeIn` and `BlurFade` start from invisible/transformed states.
+
+Impact:
+
+- On slower devices or certain rendering conditions, the page can feel blank or delayed before content settles.
+- This amplifies the perception that the mobile layout is broken.
+
+Recommended fix:
+
+- Reduce or simplify reveal effects below `md`.
+- Prefer immediate rendering for key content blocks on mobile.
+- Keep richer motion on larger screens.
+
+Desktop safety rule:
+
+- Motion reductions should be scoped to small screens or reduced-motion preferences only.
+
+---
+
+## Findings That Are Stale or Not Substantiated
+
+These points from the previous document should not be carried forward as confirmed root causes.
+
+### A. Missing `viewport` export is not proven to be the main issue
+
+Evidence:
+
+- `frontend/app/layout.tsx` does not export `viewport`.
+- But multiple pages still render at the expected mobile baseline.
+
+Conclusion:
+
+- This may be worth revisiting later, but current evidence does not support classifying it as a P0 root cause.
+- Do not anchor the remediation plan on this item.
+
+---
+
+### B. `DocsSidebar` is not missing mobile navigation
+
+Evidence:
+
+- `frontend/components/docs-sidebar.tsx:20-33`
+- There is already a mobile toggle button and conditional mobile panel.
+
+Conclusion:
+
+- The broader docs mobile experience is still poor.
+- But the old claim "docs sidebar is missing on mobile" is factually outdated.
+
+---
+
+### C. Auth shell is not currently a top-priority mobile layout issue
+
+Evidence:
+
+- Live mobile rendering for `/login` was normal.
+- `frontend/components/auth/auth-shell.tsx:17-18` uses the large split layout only under `lg`.
+- The form column remains `w-full max-w-[460px]` with mobile padding.
+
+Conclusion:
+
+- Keep it on the watch list, but do not treat it as a first-wave fix.
+
+---
+
+## Safe Optimization Principles
+
+To avoid any desktop regressions, all remediation should follow these rules.
+
+### 1. Never "fix" mobile by weakening desktop classes
+
+Good:
+
+- Add `lg:hidden` mobile alternatives
+- Add `hidden lg:block` desktop preservation
+- Add `min-w-0`, `max-w-full`, `overflow-x-auto` to mobile-sensitive containers
+
+Bad:
+
+- Removing existing desktop grid definitions
+- Changing desktop widths just to make mobile work
+- Replacing a three-column desktop layout with one shared compromise layout
+
+### 2. Avoid `body { overflow-x: hidden; }` as the primary solution
+
+Reason:
+
+- It hides symptoms.
+- It makes debugging much harder.
+- It can clip drawers, shadows, and fixed overlays.
+
+Allowed use:
+
+- Only as a last-step containment guard after the real overflow source is fixed.
+
+### 3. Prefer parallel mobile render paths for dense UI
+
+Use this for:
+
+- dashboard/admin navigation
+- docs TOC
+- dense data tables
+- API reference sidebars
+
+Do not force a desktop control to "sort of work" on phones when a dedicated mobile pattern is cleaner.
+
+### 4. Add `min-w-0` aggressively inside flex and grid layouts
+
+This is one of the lowest-risk, highest-value fixes for overflow prevention.
+
+Targets:
+
+- content columns inside grid layouts
+- card wrappers with code or tables
+- any flex row with long labels or tokens
+
+---
+
+## Detailed Update Plan
+
+## Phase 1 — Fix Functional Mobile Navigation Gaps
+
+Priority: highest
+
+Goals:
+
+- Restore dashboard navigation on mobile
+- Restore admin navigation on mobile
+- Preserve current desktop sidebars completely
+
+Files:
+
+- New: `frontend/components/dashboard/dashboard-mobile-nav.tsx`
+- Update: `frontend/components/dashboard/dashboard-top-nav.tsx`
+- Update: `frontend/components/dashboard/dashboard-app-shell.tsx`
+- New: `frontend/components/admin/admin-mobile-nav.tsx`
+- Update: `frontend/components/admin/admin-top-bar.tsx`
+- Update: `frontend/components/admin/admin-app-shell.tsx`
+
+Implementation outline:
+
+1. Add a menu button in the top bar.
+2. Open a drawer/sheet from the left.
+3. Reuse `dashboardRoutes` / `adminRoutes`.
+4. Show the active route label in the mobile top bar.
+5. Close the drawer after route selection.
+
+Acceptance criteria:
+
+- On `390px` width, users can switch between all dashboard pages.
+- On `768px` width, admin still has accessible navigation.
+- On `1440px` width, desktop sidebar appearance is unchanged.
+
+---
+
+## Phase 2 — Rebuild Docs Mobile Layout Without Touching Desktop
+
+Priority: highest
+
+Goals:
+
+- Remove horizontal overflow from docs pages
+- Give docs a true mobile navigation pattern
+- Convert TOC into a mobile-safe interaction model
+
+Files:
+
+- `frontend/app/docs/page.tsx`
+- `frontend/app/docs/api-reference/page.tsx`
+- `frontend/app/docs/search-api/page.tsx`
+- `frontend/app/docs/[slug]/page.tsx`
+- `frontend/components/docs-sidebar.tsx`
+- `frontend/components/docs-toc.tsx`
+- `frontend/components/docs-header.tsx`
+- `frontend/components/code-block.tsx`
+- Potentially a new shared docs mobile nav / toc component
+
+Implementation outline:
+
+1. Keep the existing desktop `lg:grid-cols[...]` layout.
+2. Below `lg`:
+   - move navigation access to explicit triggers
+   - hide the sticky right TOC card
+   - render a collapsible mobile TOC inside the article flow
+3. For API Reference:
+   - extract the inline sidebar into a reusable component
+   - give it both desktop and mobile variants
+4. Wrap all dense blocks with mobile containment:
+   - `min-w-0`
+   - `w-full`
+   - `max-w-full`
+   - `overflow-x-auto`
+5. Replace the densest docs tables with mobile cards instead of raw table scroll.
+6. Add a visible scroll affordance to header tabs rather than forcing wrap.
+
+Acceptance criteria:
+
+- `/docs`, `/docs/api-reference`, `/docs/search-api` all render near the normal mobile baseline width.
+- No horizontal page drag on `390px`.
+- Desktop three-column docs layout is visually unchanged on `lg+`.
+
+---
+
+## Phase 3 — Fix Homepage Overflow and Stabilize Mobile First Paint
+
+Priority: high
+
+Goals:
+
+- Remove homepage horizontal overflow
+- Improve the readability of demo content on phones
+- Reduce "blank before animate-in" perception on small screens
+
+Files:
+
+- `frontend/app/page.tsx`
+- `frontend/components/animations.tsx`
+- Possibly shared utility classes in `frontend/app/globals.css`
+
+Implementation outline:
+
+1. Audit the hero and API demo section for unbounded width.
+2. Add `min-w-0` and `max-w-full` to demo columns and wrappers where needed.
+3. Keep code block horizontal scroll, but make the surrounding card fully bounded.
+4. Reduce animation intensity below `md` for critical content sections.
+5. If decorative layers still create stray overflow, clip them at the section level instead of globally on `body`.
+
+Acceptance criteria:
+
+- `/` no longer exceeds the normal mobile width envelope.
+- Hero content is visible immediately on mobile.
+- Desktop hero layout remains the same.
+
+---
+
+## Phase 4 — Improve Dense Data Views on Mobile
+
+Priority: medium
+
+Goals:
+
+- Make pricing and docs tables readable on phones
+- Avoid making mobile users horizontally scroll through high-density comparisons
+
+Files:
+
+- `frontend/app/pricing/page.tsx`
+- Docs pages containing tables
+
+Implementation outline:
+
+1. Keep current tables on `lg+`.
+2. Render stacked cards below `lg`.
+3. For pricing:
+   - one card per tier
+   - grouped feature rows inside each card
+4. For docs:
+   - one card per parameter or error row
+
+Acceptance criteria:
+
+- Pricing remains visually identical on desktop.
+- Mobile comparisons are readable without precision horizontal scrolling.
+
+---
+
+## Phase 5 — Finish Secondary Mobile UX Gaps
+
+Priority: medium
+
+Goals:
+
+- Restore small-screen access to important public actions
+- Improve context and polish
+
+Files:
+
+- `frontend/components/site-header.tsx`
+- `frontend/components/site-header-auth-actions.tsx`
+- `frontend/components/dashboard/dashboard-top-nav.tsx`
+
+Implementation outline:
+
+1. Add a mobile GitHub affordance.
+2. Check whether the auth action loading placeholder width needs a smaller mobile version.
+3. Surface active-route context in dashboard mobile top nav.
+
+Acceptance criteria:
+
+- No more "missing GitHub action" on mobile.
+- Top bars remain stable without squeezing or wrapping awkwardly.
+
+---
+
+## QA Matrix
+
+Every phase should be verified at these widths:
+
+- `375px` — iPhone SE class
+- `390px` — iPhone 14 class
+- `768px` — iPad portrait
+- `1024px` — small laptop / iPad Pro edge
+- `1440px` — standard desktop baseline
+
+Key pages to smoke-test every time:
+
+- `/`
+- `/docs`
+- `/docs/api-reference`
+- `/docs/search-api`
+- `/pricing`
+- `/login`
+- one dashboard page
+- one admin page
+
+Required checks:
+
+- No horizontal page drag unless intentionally inside a contained code/table block
+- Navigation remains accessible
+- Desktop sidebars and column layouts are unchanged
+- No clipped drawers, popovers, or shadows
+
+---
+
+## Recommended Delivery Order
+
+1. Dashboard mobile nav
+2. Admin mobile nav
+3. Docs mobile layout system
+4. Homepage overflow fix
+5. Pricing/docs dense-table mobile variants
+6. Header and small UX polish
+
+This order fixes the true blockers first and minimizes the risk of desktop regressions.
+
+---
+
+## Execution Status
+
+Implementation status on 2026-04-13:
+
+- Phase 1 completed:
+  - added dashboard mobile navigation drawer
+  - added admin mobile navigation drawer
+  - surfaced the active route label in both mobile top bars
+- Phase 2 completed:
+  - rebuilt docs mobile navigation into overlay patterns
+  - hid the desktop sticky TOC below `lg`
+  - added a mobile TOC trigger
+  - extracted the API reference sidebar into a reusable mobile-safe component
+  - strengthened docs tab behavior so the active tab scrolls into view
+- Phase 3 completed:
+  - contained homepage overflow with `min-w-0`, `max-w-full`, and section-level clipping
+  - improved mobile header action density
+- Phase 4 completed:
+  - added mobile pricing comparison cards
+  - wrapped dense docs tables in controlled overflow containers
+- Phase 5 completed:
+  - restored a mobile GitHub affordance in the public header
+  - reduced auth-action squeeze on smaller screens
+
+### Post-fix Verification
+
+Verification steps used:
+
+1. `pnpm --dir frontend lint`
+2. `pnpm --dir frontend build`
+3. Local mobile screenshot capture in iPhone 14 emulation
+4. Visual comparison against the original overflowing pages
+
+Measured post-fix screenshot widths:
+
+| Page | Width after fix | Result |
+| --- | ---: | --- |
+| `/` | 1170 | Returned to normal mobile baseline |
+| `/pricing` | 1170 | Within baseline |
+| `/brand` | 1170 | Within baseline |
+| `/login` | 1170 | Within baseline |
+| `/docs` | 1170 | Severe overflow removed |
+| `/docs/api-reference` | 1170 | Severe overflow removed |
+| `/docs/search-api` | 1170 | Severe overflow removed |
+
+Verification conclusion:
+
+- The previously confirmed public-page mobile breakages are now resolved based on both layout inspection and live screenshot comparison.
+- The docs family no longer shows page-level horizontal overflow.
+- The homepage no longer exceeds the normal mobile width envelope.
+- Pricing now has a mobile-specific comparison pattern without changing the desktop table.
+- Desktop regression risk stayed low because the fixes used mobile-only branches such as `lg:hidden` / `xl:hidden` and preserved the existing desktop grid and sidebar layout.
+
+Remaining verification boundary:
+
+- The dashboard and admin mobile drawers were implemented and passed lint/build validation.
+- In the current local environment, unauthenticated visits to `/dashboard` and `/admin` redirect to `/login`, so final live interaction testing for those authenticated shells still needs one signed-in screenshot pass.
+
+### Additional finding after screenshot review
+
+A second mobile audit exposed another real issue:
+
+- several long pages appeared to have large blank areas near the bottom in full-page mobile screenshots
+
+Root cause:
+
+- this was not a real layout-height bug
+- the shared motion wrappers in `frontend/components/animations.tsx` used `IntersectionObserver` with initial `opacity: 0`
+- on mobile full-page capture, many below-the-fold sections never became intersecting before the screenshot was taken
+- the result looked like "large bottom whitespace" even though the page height was correct
+
+Applied fix:
+
+- preserved the desktop scroll-reveal behavior
+- added mobile and reduced-motion CSS overrides so `.motion-reveal-*` wrappers render immediately on smaller screens
+- this keeps the desktop motion style while preventing mobile screenshots and initial long-page rendering from hiding large sections of content
+
+Validated pages after the fix:
+
+- `/`
+- `/docs`
+- `/brand`
+
+Artifacts:
+
+- post-fix production screenshots saved under `/Users/jessytsui/cerul-ai/local-audits/cerul-mobile-2026-04-13/prod-blank-fix/`

--- a/frontend/app/docs/[slug]/page.tsx
+++ b/frontend/app/docs/[slug]/page.tsx
@@ -58,7 +58,7 @@ export default async function DocDetailPage({ params }: DocPageProps) {
   ];
 
   return (
-    <div className="soft-theme min-h-screen pb-10">
+    <div className="soft-theme min-h-screen overflow-x-clip pb-10">
       <DocsHeader currentPath={`/docs/${slug}`} />
 
       <div className="mx-auto max-w-[1520px] px-4 sm:px-6 lg:px-8">

--- a/frontend/app/docs/api-reference/page.tsx
+++ b/frontend/app/docs/api-reference/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { AIToolbar } from "@/components/ai-toolbar";
+import { ApiReferenceSidebar } from "@/components/api-reference-sidebar";
 import { CodeBlock } from "@/components/code-block";
 import { DocsHeader } from "@/components/docs-header";
 import { DocsTabs } from "@/components/docs-tabs";
@@ -50,60 +50,12 @@ function getMethodClasses(method: "GET" | "POST" | "DELETE") {
 
 export default function ApiReferencePage() {
   return (
-    <div className="soft-theme min-h-screen pb-10">
+    <div className="soft-theme min-h-screen overflow-x-clip pb-10">
       <DocsHeader currentPath="/docs/api-reference" />
 
       <div className="mx-auto max-w-[1520px] px-4 sm:px-6 lg:px-8">
         <div className="mt-8 grid gap-8 lg:grid-cols-[280px_minmax(0,1fr)_220px]">
-          <aside className="sticky top-20 h-fit max-h-[calc(100vh-5.5rem)] overflow-y-auto rounded-[24px] border border-[var(--border)] bg-[rgba(255,252,247,0.78)] p-4 shadow-[0_18px_40px_rgba(36,29,21,0.06)] backdrop-blur-xl">
-            <div className="border-b border-[var(--border)] pb-4">
-              <Link
-                href="/docs"
-                className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]"
-              >
-                Documentation
-              </Link>
-              <p className="mt-2 text-base font-semibold text-[var(--foreground)]">
-                API Reference
-              </p>
-              <p className="mt-1 text-sm leading-6 text-[var(--foreground-secondary)]">
-                Stable public routes only.
-              </p>
-            </div>
-
-            <div className="mt-4 space-y-5">
-              {groups.map(([groupName, endpoints]) => (
-                <section key={groupName}>
-                  <h2 className="px-2 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--foreground-tertiary)]">
-                    {groupName}
-                  </h2>
-                  <div className="mt-2 space-y-1">
-                    {endpoints.map((endpoint) => (
-                      <a
-                        key={endpoint.id}
-                        href={`#${endpoint.id}`}
-                        className="block rounded-[14px] border-l-2 border-l-transparent px-3 py-2.5 transition hover:bg-white/70"
-                      >
-                        <div className="flex items-center gap-2">
-                          <span
-                            className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${getMethodClasses(endpoint.method)}`}
-                          >
-                            {endpoint.method}
-                          </span>
-                          <span className="truncate text-sm text-[var(--foreground)]">
-                            {endpoint.path}
-                          </span>
-                        </div>
-                        <p className="mt-1 text-xs leading-5 text-[var(--foreground-secondary)]">
-                          {endpoint.title}
-                        </p>
-                      </a>
-                    ))}
-                  </div>
-                </section>
-              ))}
-            </div>
-          </aside>
+          <ApiReferenceSidebar groups={groups} />
 
           <main data-ai-copy-root="true" className="min-w-0">
             <article className="rounded-[28px] border border-[var(--border)] bg-[rgba(255,252,247,0.78)] px-6 py-8 shadow-[0_18px_48px_rgba(36,29,21,0.08)] backdrop-blur-xl sm:px-8">
@@ -237,8 +189,8 @@ export default function ApiReferencePage() {
                           </h3>
 
                           {endpoint.parameters.length > 0 ? (
-                            <div className="mt-4 overflow-hidden rounded-[20px] border border-[var(--border)]">
-                              <table className="w-full text-left text-sm">
+                            <div className="mt-4 overflow-x-auto rounded-[20px] border border-[var(--border)]">
+                              <table className="min-w-[640px] w-full text-left text-sm">
                                 <thead className="bg-[var(--background-elevated)] text-[var(--foreground-secondary)]">
                                   <tr>
                                     <th className="px-4 py-3 font-medium">Name</th>

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -32,7 +32,7 @@ const tocItems: TocItem[] = [
 
 export default function DocsPage() {
   return (
-    <div className="soft-theme min-h-screen pb-10">
+    <div className="soft-theme min-h-screen overflow-x-clip pb-10">
       <DocsHeader currentPath="/docs" />
 
       <div className="mx-auto max-w-[1520px] px-4 sm:px-6 lg:px-8">

--- a/frontend/app/docs/search-api/page.tsx
+++ b/frontend/app/docs/search-api/page.tsx
@@ -116,7 +116,7 @@ const errors: ErrorRow[] = [
 
 export default function SearchApiPage() {
   return (
-    <div className="soft-theme min-h-screen pb-10">
+    <div className="soft-theme min-h-screen overflow-x-clip pb-10">
       <DocsHeader currentPath="/docs/search-api" />
 
       <div className="mx-auto max-w-[1520px] px-4 sm:px-6 lg:px-8">
@@ -299,8 +299,8 @@ console.log(data);`}
                   </p>
                 </FadeIn>
 
-                <div className="mt-6 overflow-hidden rounded-[20px] border border-[var(--border)]">
-                  <table className="w-full text-left text-sm">
+                <div className="mt-6 overflow-x-auto rounded-[20px] border border-[var(--border)]">
+                  <table className="min-w-[640px] w-full text-left text-sm">
                     <thead className="bg-[var(--background-elevated)] text-[var(--foreground-secondary)]">
                       <tr>
                         <th className="px-4 py-3 font-medium">Name</th>
@@ -343,8 +343,8 @@ console.log(data);`}
                 </FadeIn>
 
                 <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1fr)_420px]">
-                  <div className="overflow-hidden rounded-[20px] border border-[var(--border)]">
-                    <table className="w-full text-left text-sm">
+                  <div className="overflow-x-auto rounded-[20px] border border-[var(--border)]">
+                    <table className="min-w-[640px] w-full text-left text-sm">
                       <thead className="bg-[var(--background-elevated)] text-[var(--foreground-secondary)]">
                         <tr>
                           <th className="px-4 py-3 font-medium">Name</th>
@@ -402,8 +402,8 @@ console.log(data);`}
                 </FadeIn>
 
                 <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1fr)_460px]">
-                  <div className="overflow-hidden rounded-[20px] border border-[var(--border)]">
-                    <table className="w-full text-left text-sm">
+                  <div className="overflow-x-auto rounded-[20px] border border-[var(--border)]">
+                    <table className="min-w-[640px] w-full text-left text-sm">
                       <thead className="bg-[var(--background-elevated)] text-[var(--foreground-secondary)]">
                         <tr>
                           <th className="px-4 py-3 font-medium">Field</th>
@@ -503,8 +503,8 @@ console.log(data);`}
                   />
                 </div>
 
-                <div className="mt-6 overflow-hidden rounded-[20px] border border-[var(--border)]">
-                  <table className="w-full text-left text-sm">
+                <div className="mt-6 overflow-x-auto rounded-[20px] border border-[var(--border)]">
+                  <table className="min-w-[640px] w-full text-left text-sm">
                     <thead className="bg-[var(--background-elevated)] text-[var(--foreground-secondary)]">
                       <tr>
                         <th className="px-4 py-3 font-medium">Status</th>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -294,6 +294,23 @@ button:focus-visible,
   }
 }
 
+@media (max-width: 1023px), (prefers-reduced-motion: reduce) {
+  .motion-reveal-fade,
+  .motion-reveal-blur {
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+    transition-duration: 0ms !important;
+    will-change: auto !important;
+  }
+
+  .motion-reveal-stagger > * {
+    opacity: 1 !important;
+    transform: none !important;
+    transition-duration: 0ms !important;
+  }
+}
+
 /* ========================================
    Component Styles
    ======================================== */

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -142,7 +142,7 @@ export default async function HomePage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       {showOneTap && <GoogleOneTap clientId={googleOneTapClientId} />}
-      <div className="soft-theme">
+      <div className="soft-theme overflow-x-clip">
         <div className="relative z-10 mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-10 pt-4 sm:px-6 lg:px-8">
           <SiteHeader currentPath="/" />
 
@@ -175,10 +175,10 @@ export default async function HomePage() {
 
               {/* API Demo — two-column layout */}
               <FadeIn delay={500} className="mt-20">
-                <div className="mx-auto grid gap-8 lg:grid-cols-2 items-start">
+                <div className="mx-auto grid items-start gap-8 lg:grid-cols-2">
                   {/* Left: curl terminal + description */}
-                  <div className="flex flex-col">
-                    <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[#1a1614] shadow-xl">
+                  <div className="min-w-0 flex flex-col">
+                    <div className="max-w-full overflow-hidden rounded-2xl border border-[var(--border)] bg-[#1a1614] shadow-xl">
                       <div className="flex items-center gap-3 border-b border-white/10 px-5 py-3.5">
                         <div className="flex gap-1.5">
                           <span className="h-3 w-3 rounded-full bg-red-400/80" />
@@ -190,7 +190,7 @@ export default async function HomePage() {
                         </span>
                         <span className="ml-auto text-xs text-white/30">search.sh</span>
                       </div>
-                      <pre className="px-6 py-8 font-mono text-[13px] leading-relaxed text-[#e8e4dc] sm:text-sm lg:text-base overflow-x-auto">
+                      <pre className="overflow-x-auto px-6 py-8 font-mono text-sm leading-relaxed text-[#e8e4dc] lg:text-base">
                         <code>{`curl "https://api.cerul.ai/v1/search" \\
   -H "Authorization: Bearer YOUR_CERUL_API_KEY" \\
   -d '{
@@ -215,7 +215,7 @@ export default async function HomePage() {
                   </div>
 
                   {/* Right: video result */}
-                  <div className="flex flex-col rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-xl">
+                  <div className="min-w-0 flex flex-col rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-xl">
                     {/* Video thumbnail */}
                     <a
                       href="https://cerul.ai/v/homepage1"

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -28,8 +28,28 @@ const featuresComparison = [
 ];
 
 export default function PricingPage() {
+  const planKeys = ["free", "payg", "pro", "enterprise"] as const;
+
+  const renderComparisonValue = (value: boolean | string, highlight?: boolean) => (
+    typeof value === "boolean" ? (
+      value ? (
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-[rgba(31,141,74,0.18)] bg-[rgba(31,141,74,0.12)] text-[var(--success)]">
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </span>
+      ) : (
+        <span className="text-[var(--foreground-tertiary)]">&mdash;</span>
+      )
+    ) : (
+      <span className={`text-sm ${highlight ? "font-medium text-[var(--foreground)]" : "text-[var(--foreground-secondary)]"}`}>
+        {value}
+      </span>
+    )
+  );
+
   return (
-    <div className="soft-theme">
+    <div className="soft-theme overflow-x-clip">
       <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col px-4 pb-8 pt-4 sm:px-6 lg:px-8">
         <SiteHeader currentPath="/pricing" />
         <main className="flex-1">
@@ -158,7 +178,57 @@ export default function PricingPage() {
             </FadeIn>
 
             <FadeIn delay={100}>
-              <div className="mt-8 overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--surface)]">
+              <div className="mt-8 grid gap-4 lg:hidden">
+                {pricingTiers.map((tier, tierIndex) => {
+                  const planKey = planKeys[tierIndex];
+
+                  return (
+                    <div
+                      key={tier.name}
+                      className={`rounded-3xl border p-6 ${
+                        planKey === "pro"
+                          ? "border-[var(--border-brand)] bg-gradient-to-b from-[var(--surface)] to-[var(--background-elevated)]"
+                          : "border-[var(--border)] bg-[var(--surface)]"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-4 border-b border-[var(--border)] pb-4">
+                        <div>
+                          <p className="text-sm font-medium uppercase tracking-wider text-[var(--brand-bright)]">
+                            {tier.name}
+                          </p>
+                          <p className="mt-2 text-2xl font-bold text-[var(--foreground)]">
+                            {tier.price}
+                          </p>
+                          <p className="mt-1 text-sm text-[var(--foreground-tertiary)]">
+                            {tier.cadence}
+                          </p>
+                        </div>
+                        {planKey === "pro" ? (
+                          <span className="rounded-full border border-[var(--border-brand)] bg-[var(--brand-subtle)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--brand-bright)]">
+                            Popular
+                          </span>
+                        ) : null}
+                      </div>
+
+                      <div className="mt-4 space-y-3">
+                        {featuresComparison.map((feature) => (
+                          <div
+                            key={`${tier.name}-${feature.name}`}
+                            className="flex items-start justify-between gap-4 rounded-[18px] border border-[var(--border)] bg-[var(--background-elevated)] px-4 py-3"
+                          >
+                            <p className="text-sm text-[var(--foreground)]">{feature.name}</p>
+                            <div className="shrink-0 text-right">
+                              {renderComparisonValue(feature[planKey], planKey === "pro")}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="mt-8 hidden overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--surface)] lg:block">
                 <div className="overflow-x-auto">
                   <table className="w-full">
                     <thead>
@@ -182,32 +252,16 @@ export default function PricingPage() {
                     </thead>
                     <tbody>
                       {featuresComparison.map((feature, index) => {
-                        const renderCell = (value: boolean | string, highlight?: boolean) => (
-                          typeof value === "boolean" ? (
-                            value ? (
-                              <svg className="mx-auto h-5 w-5 text-[var(--success)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                              </svg>
-                            ) : (
-                              <span className="text-[var(--foreground-tertiary)]">&mdash;</span>
-                            )
-                          ) : (
-                            <span className={`text-sm ${highlight ? "font-medium text-[var(--foreground)]" : "text-[var(--foreground-secondary)]"}`}>
-                              {value}
-                            </span>
-                          )
-                        );
-
                         return (
                           <tr
                             key={feature.name}
                             className={index !== featuresComparison.length - 1 ? "border-b border-[var(--border)]" : ""}
                           >
                             <td className="px-6 py-4 text-sm text-[var(--foreground)]">{feature.name}</td>
-                            <td className="px-6 py-4 text-center">{renderCell(feature.free)}</td>
-                            <td className="px-6 py-4 text-center">{renderCell(feature.payg)}</td>
-                            <td className="px-6 py-4 text-center bg-[var(--brand-subtle)]/30">{renderCell(feature.pro, true)}</td>
-                            <td className="px-6 py-4 text-center">{renderCell(feature.enterprise)}</td>
+                            <td className="px-6 py-4 text-center">{renderComparisonValue(feature.free)}</td>
+                            <td className="px-6 py-4 text-center">{renderComparisonValue(feature.payg)}</td>
+                            <td className="px-6 py-4 text-center bg-[var(--brand-subtle)]/30">{renderComparisonValue(feature.pro, true)}</td>
+                            <td className="px-6 py-4 text-center">{renderComparisonValue(feature.enterprise)}</td>
                           </tr>
                         );
                       })}

--- a/frontend/components/admin/admin-mobile-nav.tsx
+++ b/frontend/components/admin/admin-mobile-nav.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import type { Route } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import {
+  adminRoutes,
+  isAdminRouteActive,
+} from "@/lib/site";
+
+type AdminMobileNavProps = {
+  currentPath: string;
+  activeRoute: string;
+};
+
+export function AdminMobileNav({
+  currentPath,
+  activeRoute,
+}: AdminMobileNavProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <div className="flex items-center gap-3 xl:hidden">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-label={open ? "Close admin navigation" : "Open admin navigation"}
+          onClick={() => setOpen((value) => !value)}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-white/72 text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:bg-white hover:text-[var(--foreground)]"
+        >
+          {open ? <CloseIcon /> : <MenuIcon />}
+        </button>
+
+        <div className="min-w-0">
+          <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-[var(--brand-bright)]">
+            Admin
+          </p>
+          <p className="truncate text-sm font-medium text-[var(--foreground)]">
+            {activeRoute}
+          </p>
+        </div>
+      </div>
+
+      {open ? (
+        <div className="fixed inset-0 z-[140] xl:hidden">
+          <button
+            type="button"
+            aria-label="Close admin navigation"
+            onClick={() => setOpen(false)}
+            className="absolute inset-0 bg-[rgba(36,29,21,0.32)] backdrop-blur-sm"
+          />
+
+          <aside className="absolute inset-y-0 left-0 flex w-[min(88vw,360px)] max-w-full flex-col border-r border-[var(--border)] bg-[rgba(255,252,247,0.98)] px-5 py-5 shadow-[0_24px_80px_rgba(36,29,21,0.18)]">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-[var(--brand-bright)]">
+                  Admin
+                </p>
+                <p className="mt-1 text-base font-semibold text-[var(--foreground)]">
+                  Navigation
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close admin navigation"
+                onClick={() => setOpen(false)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-white/80 text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            <nav className="mt-6 space-y-2">
+              {adminRoutes.map((item) => {
+                const isActive = isAdminRouteActive(currentPath, item.href);
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href as Route}
+                    onClick={() => setOpen(false)}
+                    className={`flex items-center justify-between rounded-[18px] border px-4 py-3 transition ${
+                      isActive
+                        ? "border-[var(--border-brand)] bg-[var(--brand-subtle)] text-[var(--foreground)]"
+                        : "border-transparent bg-white/46 text-[var(--foreground-secondary)] hover:border-[var(--border)] hover:bg-white hover:text-[var(--foreground)]"
+                    }`}
+                  >
+                    <span className="text-sm font-medium">{item.label}</span>
+                    <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--foreground-tertiary)]">
+                      {item.meta}
+                    </span>
+                  </Link>
+                );
+              })}
+            </nav>
+
+            <div className="mt-6 border-t border-[var(--border)] pt-6">
+              <p className="px-1 text-[10px] font-medium uppercase tracking-[0.16em] text-[var(--foreground-tertiary)]">
+                Shortcuts
+              </p>
+              <div className="mt-3 space-y-2">
+                <Link
+                  href={"/dashboard" as Route}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center justify-between rounded-[18px] border border-transparent px-4 py-3 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border)] hover:bg-white hover:text-[var(--foreground)]"
+                >
+                  <span>Dashboard</span>
+                  <ArrowRightIcon />
+                </Link>
+                <Link
+                  href={"/docs" as Route}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center justify-between rounded-[18px] border border-transparent px-4 py-3 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border)] hover:bg-white hover:text-[var(--foreground)]"
+                >
+                  <span>Documentation</span>
+                  <ArrowRightIcon />
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function MenuIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M4 7h16M4 12h16M4 17h16" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M6 6l12 12M18 6 6 18" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}
+
+function ArrowRightIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M4.5 12h15m0 0-5.25-5.25M19.5 12l-5.25 5.25" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}

--- a/frontend/components/admin/admin-top-bar.tsx
+++ b/frontend/components/admin/admin-top-bar.tsx
@@ -3,6 +3,7 @@
 import type { Route } from "next";
 import Link from "next/link";
 import { adminRoutes, isAdminRouteActive } from "@/lib/site";
+import { AdminMobileNav } from "./admin-mobile-nav";
 import { UserAvatarMenu } from "./user-avatar-menu";
 
 type AdminTopBarProps = {
@@ -19,6 +20,8 @@ export function AdminTopBar({ currentPath, title }: AdminTopBarProps) {
   return (
     <header className="border-b border-[var(--border)] bg-white/34 backdrop-blur-xl">
       <div className="mx-auto flex max-w-[1240px] items-center justify-between gap-4 px-5 py-4 sm:px-6 lg:px-8">
+        <AdminMobileNav currentPath={currentPath} activeRoute={activeRoute} />
+
         <div className="hidden items-center gap-2 text-sm md:flex">
           <span className="rounded-full border border-[var(--border-brand)] bg-[var(--brand-subtle)] px-3 py-1 text-[var(--brand-bright)]">
             Admin

--- a/frontend/components/animations.tsx
+++ b/frontend/components/animations.tsx
@@ -14,6 +14,22 @@ interface FadeInProps {
   once?: boolean;
 }
 
+function useMountedReveal() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const frameId = window.requestAnimationFrame(() => {
+      setIsVisible(true);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, []);
+
+  return isVisible;
+}
+
 export function FadeIn({
   children,
   delay = 0,
@@ -21,32 +37,8 @@ export function FadeIn({
   direction = "up",
   distance = 24,
   className = "",
-  once = true,
 }: FadeInProps) {
-  const [isVisible, setIsVisible] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          setIsVisible(true);
-          if (once && ref.current) {
-            observer.unobserve(ref.current);
-          }
-        } else if (!once) {
-          setIsVisible(false);
-        }
-      },
-      { threshold: 0.1, rootMargin: "0px 0px -50px 0px" }
-    );
-
-    if (ref.current) {
-      observer.observe(ref.current);
-    }
-
-    return () => observer.disconnect();
-  }, [once]);
+  const isVisible = useMountedReveal();
 
   const getTransform = () => {
     if (direction === "none") return "translate3d(0, 0, 0)";
@@ -67,8 +59,7 @@ export function FadeIn({
 
   return (
     <div
-      ref={ref}
-      className={className}
+      className={`motion-reveal-fade ${className}`.trim()}
       style={{
         opacity: isVisible ? 1 : 0,
         transform: getTransform(),
@@ -94,31 +85,10 @@ export function StaggerContainer({
   staggerDelay = 100,
   baseDelay = 0,
 }: StaggerContainerProps) {
-  const [isVisible, setIsVisible] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          setIsVisible(true);
-          if (ref.current) {
-            observer.unobserve(ref.current);
-          }
-        }
-      },
-      { threshold: 0.1, rootMargin: "0px 0px -50px 0px" }
-    );
-
-    if (ref.current) {
-      observer.observe(ref.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
+  const isVisible = useMountedReveal();
 
   return (
-    <div ref={ref} className={className}>
+    <div className={`motion-reveal-stagger ${className}`.trim()}>
       {Array.isArray(children)
         ? children.map((child, index) => (
             <div
@@ -268,41 +238,37 @@ export function AnimatedCounter({
   className = "",
 }: AnimatedCounterProps) {
   const [count, setCount] = useState(0);
-  const ref = useRef<HTMLSpanElement>(null);
-  const hasAnimated = useRef(false);
 
   useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting && !hasAnimated.current) {
-          hasAnimated.current = true;
-          const startTime = Date.now();
-          const animate = () => {
-            const elapsed = Date.now() - startTime;
-            const progress = Math.min(elapsed / duration, 1);
-            const easeOutQuart = 1 - Math.pow(1 - progress, 4);
-            setCount(Math.floor(easeOutQuart * value));
-            if (progress < 1) {
-              requestAnimationFrame(animate);
-            } else {
-              setCount(value);
-            }
-          };
-          requestAnimationFrame(animate);
-        }
-      },
-      { threshold: 0.5 }
-    );
+    let frameId = 0;
+    let startTime = 0;
 
-    if (ref.current) {
-      observer.observe(ref.current);
-    }
+    const animate = (timestamp: number) => {
+      if (!startTime) {
+        startTime = timestamp;
+      }
 
-    return () => observer.disconnect();
+      const elapsed = timestamp - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const easeOutQuart = 1 - Math.pow(1 - progress, 4);
+      setCount(Math.floor(easeOutQuart * value));
+
+      if (progress < 1) {
+        frameId = requestAnimationFrame(animate);
+      } else {
+        setCount(value);
+      }
+    };
+
+    frameId = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
   }, [value, duration]);
 
   return (
-    <span ref={ref} className={className}>
+    <span className={className}>
       {prefix}
       {count.toLocaleString()}
       {suffix}
@@ -321,33 +287,11 @@ export function BlurFade({
   delay = 0,
   className = "",
 }: BlurFadeProps) {
-  const [isVisible, setIsVisible] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          setIsVisible(true);
-          if (ref.current) {
-            observer.unobserve(ref.current);
-          }
-        }
-      },
-      { threshold: 0.1 }
-    );
-
-    if (ref.current) {
-      observer.observe(ref.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
+  const isVisible = useMountedReveal();
 
   return (
     <div
-      ref={ref}
-      className={className}
+      className={`motion-reveal-blur ${className}`.trim()}
       style={{
         opacity: isVisible ? 1 : 0,
         filter: isVisible ? "blur(0px)" : "blur(10px)",

--- a/frontend/components/api-reference-sidebar.tsx
+++ b/frontend/components/api-reference-sidebar.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+type ApiReferenceEndpoint = {
+  id: string;
+  method: "GET" | "POST" | "DELETE";
+  path: string;
+  title: string;
+};
+
+type ApiReferenceSidebarProps = {
+  groups: Array<[string, ApiReferenceEndpoint[]]>;
+};
+
+export function ApiReferenceSidebar({
+  groups,
+}: ApiReferenceSidebarProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mb-4 flex w-full items-center justify-between rounded-[16px] border border-[var(--border)] bg-[rgba(255,252,247,0.76)] px-4 py-3 text-left text-sm text-[var(--foreground-secondary)] shadow-[0_12px_28px_rgba(36,29,21,0.05)] lg:hidden"
+      >
+        <span>API navigation</span>
+        <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--brand-bright)]">
+          Open
+        </span>
+      </button>
+
+      {open ? (
+        <div className="fixed inset-0 z-[135] lg:hidden">
+          <button
+            type="button"
+            aria-label="Close API navigation"
+            onClick={() => setOpen(false)}
+            className="absolute inset-0 bg-[rgba(36,29,21,0.32)] backdrop-blur-sm"
+          />
+
+          <aside className="absolute inset-y-0 left-0 w-[min(88vw,360px)] max-w-full overflow-y-auto border-r border-[var(--border)] bg-[rgba(255,252,247,0.98)] p-5 shadow-[0_24px_80px_rgba(36,29,21,0.18)]">
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] pb-4">
+              <div>
+                <Link
+                  href="/docs"
+                  onClick={() => setOpen(false)}
+                  className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]"
+                >
+                  Documentation
+                </Link>
+                <p className="mt-2 text-base font-semibold text-[var(--foreground)]">
+                  API Reference
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close API navigation"
+                onClick={() => setOpen(false)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-white/80 text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            <div className="mt-4 space-y-5">
+              {groups.map(([groupName, endpoints]) => (
+                <section key={groupName}>
+                  <h2 className="px-2 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--foreground-tertiary)]">
+                    {groupName}
+                  </h2>
+                  <div className="mt-2 space-y-1">
+                    {endpoints.map((endpoint) => (
+                      <a
+                        key={endpoint.id}
+                        href={`#${endpoint.id}`}
+                        onClick={() => setOpen(false)}
+                        className="block rounded-[14px] border-l-2 border-l-transparent px-3 py-2.5 transition hover:bg-white/70"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${getMethodClasses(endpoint.method)}`}
+                          >
+                            {endpoint.method}
+                          </span>
+                          <span className="truncate text-sm text-[var(--foreground)]">
+                            {endpoint.path}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs leading-5 text-[var(--foreground-secondary)]">
+                          {endpoint.title}
+                        </p>
+                      </a>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </aside>
+        </div>
+      ) : null}
+
+      <aside className="hidden lg:block">
+        <div className="sticky top-20 h-fit max-h-[calc(100vh-5.5rem)] overflow-y-auto rounded-[24px] border border-[var(--border)] bg-[rgba(255,252,247,0.78)] p-4 shadow-[0_18px_40px_rgba(36,29,21,0.06)] backdrop-blur-xl">
+          <div className="border-b border-[var(--border)] pb-4">
+            <Link
+              href="/docs"
+              className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]"
+            >
+              Documentation
+            </Link>
+            <p className="mt-2 text-base font-semibold text-[var(--foreground)]">
+              API Reference
+            </p>
+            <p className="mt-1 text-sm leading-6 text-[var(--foreground-secondary)]">
+              Stable public routes only.
+            </p>
+          </div>
+
+          <div className="mt-4 space-y-5">
+            {groups.map(([groupName, endpoints]) => (
+              <section key={groupName}>
+                <h2 className="px-2 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--foreground-tertiary)]">
+                  {groupName}
+                </h2>
+                <div className="mt-2 space-y-1">
+                  {endpoints.map((endpoint) => (
+                    <a
+                      key={endpoint.id}
+                      href={`#${endpoint.id}`}
+                      className="block rounded-[14px] border-l-2 border-l-transparent px-3 py-2.5 transition hover:bg-white/70"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${getMethodClasses(endpoint.method)}`}
+                        >
+                          {endpoint.method}
+                        </span>
+                        <span className="truncate text-sm text-[var(--foreground)]">
+                          {endpoint.path}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs leading-5 text-[var(--foreground-secondary)]">
+                        {endpoint.title}
+                      </p>
+                    </a>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function getMethodClasses(method: "GET" | "POST" | "DELETE") {
+  if (method === "GET") {
+    return "border-[rgba(31,141,74,0.18)] bg-[rgba(31,141,74,0.12)] text-[var(--success)]";
+  }
+
+  if (method === "DELETE") {
+    return "border-[rgba(191,91,70,0.18)] bg-[rgba(191,91,70,0.12)] text-[var(--error)]";
+  }
+
+  return "border-[var(--border-brand)] bg-[var(--brand-subtle)] text-[var(--brand-bright)]";
+}
+
+function CloseIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M6 6l12 12M18 6 6 18" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}

--- a/frontend/components/code-block.tsx
+++ b/frontend/components/code-block.tsx
@@ -26,7 +26,7 @@ export function CodeBlock({
   }
 
   return (
-    <div className="overflow-hidden rounded-[20px] border border-[#2b2621] bg-[#15120f] shadow-[0_18px_44px_rgba(20,15,11,0.22)]">
+    <div className="min-w-0 max-w-full overflow-hidden rounded-[20px] border border-[#2b2621] bg-[#15120f] shadow-[0_18px_44px_rgba(20,15,11,0.22)]">
       <div className="flex items-center justify-between gap-3 border-b border-white/8 bg-[#1d1916] px-4 py-3">
         <div className="flex min-w-0 items-center gap-3">
           <div className="min-w-0">
@@ -46,7 +46,7 @@ export function CodeBlock({
           {copied ? "Copied" : "Copy"}
         </button>
       </div>
-      <pre className="overflow-x-auto px-4 py-5 font-mono text-sm leading-7 text-[#f6f1e7]">
+      <pre className="max-w-full overflow-x-auto px-4 py-5 font-mono text-sm leading-7 text-[#f6f1e7]">
         <code>{code}</code>
       </pre>
     </div>

--- a/frontend/components/dashboard/dashboard-mobile-nav.tsx
+++ b/frontend/components/dashboard/dashboard-mobile-nav.tsx
@@ -44,7 +44,7 @@ export function DashboardMobileNav({
 
   return (
     <>
-      <div className="flex items-center gap-3 md:hidden">
+      <div className="flex items-center gap-3 lg:hidden">
         <button
           type="button"
           aria-expanded={open}

--- a/frontend/components/dashboard/dashboard-mobile-nav.tsx
+++ b/frontend/components/dashboard/dashboard-mobile-nav.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import type { Route } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useConsoleViewer } from "@/components/console/console-viewer-context";
+import {
+  dashboardRoutes,
+  isDashboardRouteActive,
+} from "@/lib/site";
+
+type DashboardMobileNavProps = {
+  currentPath: string;
+  activeRoute: string;
+};
+
+export function DashboardMobileNav({
+  currentPath,
+  activeRoute,
+}: DashboardMobileNavProps) {
+  const [open, setOpen] = useState(false);
+  const viewer = useConsoleViewer();
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <div className="flex items-center gap-3 md:hidden">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-label={open ? "Close dashboard navigation" : "Open dashboard navigation"}
+          onClick={() => setOpen((value) => !value)}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--background-elevated,white)] text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+        >
+          {open ? <CloseIcon /> : <MenuIcon />}
+        </button>
+
+        <div className="min-w-0">
+          <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-[var(--foreground-tertiary)]">
+            Console
+          </p>
+          <p className="truncate text-sm font-medium text-[var(--foreground)]">
+            {activeRoute}
+          </p>
+        </div>
+      </div>
+
+      {open ? (
+        <div className="fixed inset-0 z-[140] lg:hidden">
+          <button
+            type="button"
+            aria-label="Close dashboard navigation"
+            onClick={() => setOpen(false)}
+            className="absolute inset-0 bg-[rgba(36,29,21,0.32)] backdrop-blur-sm"
+          />
+
+          <aside className="absolute inset-y-0 left-0 flex w-[min(88vw,360px)] max-w-full flex-col border-r border-[var(--border)] bg-[rgba(255,252,247,0.98)] px-5 py-5 shadow-[0_24px_80px_rgba(36,29,21,0.18)]">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-[var(--foreground-tertiary)]">
+                  Dashboard
+                </p>
+                <p className="mt-1 text-base font-semibold text-[var(--foreground)]">
+                  Navigation
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close dashboard navigation"
+                onClick={() => setOpen(false)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-white/80 text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            <nav className="mt-6 space-y-2">
+              {dashboardRoutes.map((item) => {
+                const isActive = isDashboardRouteActive(currentPath, item.href);
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href as Route}
+                    onClick={() => setOpen(false)}
+                    className={`flex items-center justify-between rounded-[18px] border px-4 py-3 transition ${
+                      isActive
+                        ? "border-[var(--border-brand)] bg-[var(--brand-subtle)] text-[var(--foreground)]"
+                        : "border-transparent bg-white/46 text-[var(--foreground-secondary)] hover:border-[var(--border)] hover:bg-white hover:text-[var(--foreground)]"
+                    }`}
+                  >
+                    <span className="text-sm font-medium">{item.label}</span>
+                    <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--foreground-tertiary)]">
+                      {item.meta}
+                    </span>
+                  </Link>
+                );
+              })}
+            </nav>
+
+            <div className="mt-6 border-t border-[var(--border)] pt-6">
+              <p className="px-1 text-[10px] font-medium uppercase tracking-[0.16em] text-[var(--foreground-tertiary)]">
+                Shortcuts
+              </p>
+              <div className="mt-3 space-y-2">
+                <Link
+                  href={"/docs" as Route}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center justify-between rounded-[18px] border border-transparent px-4 py-3 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border)] hover:bg-white hover:text-[var(--foreground)]"
+                >
+                  <span>Documentation</span>
+                  <ArrowRightIcon />
+                </Link>
+                <Link
+                  href={"/pricing" as Route}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center justify-between rounded-[18px] border border-transparent px-4 py-3 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border)] hover:bg-white hover:text-[var(--foreground)]"
+                >
+                  <span>Pricing</span>
+                  <ArrowRightIcon />
+                </Link>
+                {viewer.isAdmin ? (
+                  <Link
+                    href={"/admin" as Route}
+                    onClick={() => setOpen(false)}
+                    className="flex items-center justify-between rounded-[18px] border border-transparent px-4 py-3 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border)] hover:bg-white hover:text-[var(--foreground)]"
+                  >
+                    <span>Admin Console</span>
+                    <ArrowRightIcon />
+                  </Link>
+                ) : null}
+              </div>
+            </div>
+          </aside>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function MenuIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M4 7h16M4 12h16M4 17h16" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M6 6l12 12M18 6 6 18" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}
+
+function ArrowRightIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M4.5 12h15m0 0-5.25-5.25M19.5 12l-5.25 5.25" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
+  );
+}

--- a/frontend/components/dashboard/dashboard-top-nav.tsx
+++ b/frontend/components/dashboard/dashboard-top-nav.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useConsoleViewer } from "@/components/console/console-viewer-context";
 import { dashboardRoutes, isDashboardRouteActive } from "@/lib/site";
 import { DashboardTopAccountControls } from "./dashboard-top-account-controls";
+import { DashboardMobileNav } from "./dashboard-mobile-nav";
 
 type DashboardTopNavProps = {
   currentPath: string;
@@ -20,6 +21,8 @@ export function DashboardTopNav({
   return (
     <header className="animate-fade-in relative z-[80] overflow-visible border-b border-[var(--border)] bg-[var(--background,white)] backdrop-blur-xl">
       <div className="mx-auto flex max-w-[1120px] items-center justify-between gap-4 px-5 py-4 sm:px-6 lg:px-8">
+        <DashboardMobileNav currentPath={currentPath} activeRoute={activeRoute} />
+
         <div className="hidden items-center gap-2 text-sm md:flex">
           <span className="rounded-full border border-[var(--border)] bg-white/72 px-3 py-1 text-[var(--foreground-tertiary)]">
             Pages

--- a/frontend/components/docs-header.tsx
+++ b/frontend/components/docs-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDeferredValue, useEffect, useState } from "react";
+import { useDeferredValue, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { BrandMark } from "@/components/brand-mark";
 import {
@@ -29,6 +29,7 @@ export function DocsHeader({ currentPath }: DocsHeaderProps) {
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const searchEntries = getDocsSearchEntries();
+  const activeTabRef = useRef<HTMLAnchorElement | null>(null);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -55,6 +56,14 @@ export function DocsHeader({ currentPath }: DocsHeaderProps) {
       const haystack = `${entry.title} ${entry.description} ${entry.category}`.toLowerCase();
       return haystack.includes(normalizedQuery);
     });
+
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({
+      block: "nearest",
+      inline: "center",
+      behavior: "smooth",
+    });
+  }, [currentPath]);
 
   return (
     <>
@@ -123,6 +132,7 @@ export function DocsHeader({ currentPath }: DocsHeaderProps) {
                 <Link
                   key={item.href}
                   href={item.href}
+                  ref={active ? activeTabRef : undefined}
                   className={`whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition ${
                     active
                       ? "bg-white text-[var(--foreground)] shadow-[0_10px_24px_rgba(36,29,21,0.06)]"

--- a/frontend/components/docs-sidebar.tsx
+++ b/frontend/components/docs-sidebar.tsx
@@ -13,6 +13,8 @@ type DocsSidebarProps = {
 export function DocsSidebar({ currentSlug, currentPath }: DocsSidebarProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const panelId = useId();
+  const mobilePanelId = `${panelId}-mobile`;
+  const desktopPanelId = `${panelId}-desktop`;
   const activeKey = currentSlug ?? currentPath ?? "/docs";
 
   useEffect(() => {
@@ -39,7 +41,7 @@ export function DocsSidebar({ currentSlug, currentPath }: DocsSidebarProps) {
   return (
     <>
       <button
-        aria-controls={panelId}
+        aria-controls={mobilePanelId}
         aria-expanded={mobileOpen}
         type="button"
         onClick={() => setMobileOpen(!mobileOpen)}
@@ -61,7 +63,7 @@ export function DocsSidebar({ currentSlug, currentPath }: DocsSidebarProps) {
           />
 
           <aside
-            id={panelId}
+            id={mobilePanelId}
             className="absolute inset-y-0 left-0 w-[min(88vw,360px)] max-w-full overflow-y-auto border-r border-[var(--border)] bg-[rgba(255,252,247,0.98)] p-5 shadow-[0_24px_80px_rgba(36,29,21,0.18)]"
           >
             <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] pb-4">
@@ -156,7 +158,7 @@ export function DocsSidebar({ currentSlug, currentPath }: DocsSidebarProps) {
         </div>
       ) : null}
 
-      <aside id={panelId} className="hidden lg:block">
+      <aside id={desktopPanelId} className="hidden lg:block">
         <div className="sticky top-20 max-h-[calc(100vh-5.5rem)] overflow-y-auto rounded-[24px] border border-[var(--border)] bg-[rgba(255,252,247,0.76)] p-4 shadow-[0_18px_40px_rgba(36,29,21,0.06)] backdrop-blur-xl">
           <div className="border-b border-[var(--border)] pb-4">
             <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]">

--- a/frontend/components/docs-sidebar.tsx
+++ b/frontend/components/docs-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import type { Route } from "next";
 import Link from "next/link";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { docsSidebarGroups, docsUtilityLinks } from "@/lib/docs";
 
 type DocsSidebarProps = {
@@ -14,6 +14,27 @@ export function DocsSidebar({ currentSlug, currentPath }: DocsSidebarProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const panelId = useId();
   const activeKey = currentSlug ?? currentPath ?? "/docs";
+
+  useEffect(() => {
+    if (!mobileOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMobileOpen(false);
+      }
+    };
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [mobileOpen]);
 
   return (
     <>
@@ -30,7 +51,112 @@ export function DocsSidebar({ currentSlug, currentPath }: DocsSidebarProps) {
         </span>
       </button>
 
-      <aside id={panelId} className={`${mobileOpen ? "block" : "hidden"} lg:block`}>
+      {mobileOpen ? (
+        <div className="fixed inset-0 z-[135] lg:hidden">
+          <button
+            type="button"
+            aria-label="Close docs navigation"
+            onClick={() => setMobileOpen(false)}
+            className="absolute inset-0 bg-[rgba(36,29,21,0.32)] backdrop-blur-sm"
+          />
+
+          <aside
+            id={panelId}
+            className="absolute inset-y-0 left-0 w-[min(88vw,360px)] max-w-full overflow-y-auto border-r border-[var(--border)] bg-[rgba(255,252,247,0.98)] p-5 shadow-[0_24px_80px_rgba(36,29,21,0.18)]"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] pb-4">
+              <div>
+                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]">
+                  Documentation
+                </p>
+                <p className="mt-2 text-base font-semibold text-[var(--foreground)]">
+                  Cerul API
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close docs navigation"
+                onClick={() => setMobileOpen(false)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-white/80 text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2 border-b border-[var(--border)] pb-4">
+              {docsUtilityLinks.map((item) => {
+                const isExternal = item.href.startsWith("http") || item.href.startsWith("mailto:");
+
+                if (isExternal) {
+                  return (
+                    <a
+                      key={item.href}
+                      href={item.href}
+                      target={item.href.startsWith("http") ? "_blank" : undefined}
+                      rel={item.href.startsWith("http") ? "noreferrer" : undefined}
+                      onClick={() => setMobileOpen(false)}
+                      className="rounded-full border border-[var(--border)] bg-[var(--background-elevated)] px-3 py-2 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:bg-white hover:text-[var(--foreground)]"
+                    >
+                      {item.title}
+                    </a>
+                  );
+                }
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href as Route}
+                    onClick={() => setMobileOpen(false)}
+                    className="rounded-full border border-[var(--border)] bg-[var(--background-elevated)] px-3 py-2 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:bg-white hover:text-[var(--foreground)]"
+                  >
+                    {item.title}
+                  </Link>
+                );
+              })}
+            </div>
+
+            <div className="mt-4 space-y-5">
+              {docsSidebarGroups.map((group) => (
+                <section key={group.title}>
+                  <h3 className="px-2 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--foreground-tertiary)]">
+                    {group.title}
+                  </h3>
+                  <div className="mt-2 space-y-1">
+                    {group.items.map((item) => {
+                      const isActive =
+                        (item.slug && item.slug === activeKey)
+                        || item.href === activeKey
+                        || item.href === currentPath;
+
+                      return (
+                        <Link
+                          key={item.href}
+                          href={item.href as Route}
+                          onClick={() => setMobileOpen(false)}
+                          className={`block rounded-[14px] border-l-2 px-3 py-2.5 transition ${
+                            isActive
+                              ? "border-l-[var(--brand-bright)] bg-[var(--brand-subtle)] text-[var(--foreground)]"
+                              : "border-l-transparent text-[var(--foreground-secondary)] hover:bg-white/70 hover:text-[var(--foreground)]"
+                          }`}
+                        >
+                          <p className="text-sm font-medium">{item.title}</p>
+                          {item.description ? (
+                            <p className="mt-1 text-xs leading-5 text-[var(--foreground-tertiary)]">
+                              {item.description}
+                            </p>
+                          ) : null}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </aside>
+        </div>
+      ) : null}
+
+      <aside id={panelId} className="hidden lg:block">
         <div className="sticky top-20 max-h-[calc(100vh-5.5rem)] overflow-y-auto rounded-[24px] border border-[var(--border)] bg-[rgba(255,252,247,0.76)] p-4 shadow-[0_18px_40px_rgba(36,29,21,0.06)] backdrop-blur-xl">
           <div className="border-b border-[var(--border)] pb-4">
             <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]">
@@ -112,5 +238,13 @@ export function DocsSidebar({ currentSlug, currentPath }: DocsSidebarProps) {
         </div>
       </aside>
     </>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M6 6l12 12M18 6 6 18" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
   );
 }

--- a/frontend/components/docs-tabs.tsx
+++ b/frontend/components/docs-tabs.tsx
@@ -48,11 +48,11 @@ export function DocsTabs({ items, defaultValue }: DocsTabsProps) {
   }
 
   return (
-    <div className="overflow-hidden rounded-[20px] border border-[var(--border)] bg-[rgba(255,252,247,0.72)] shadow-[0_14px_36px_rgba(36,29,21,0.06)]">
+    <div className="min-w-0 max-w-full overflow-hidden rounded-[20px] border border-[var(--border)] bg-[rgba(255,252,247,0.72)] shadow-[0_14px_36px_rgba(36,29,21,0.06)]">
       <div
         aria-label="Code examples"
         role="tablist"
-        className="flex gap-2 overflow-x-auto border-b border-[var(--border)] bg-[rgba(255,255,255,0.48)] px-3 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex max-w-full gap-2 overflow-x-auto border-b border-[var(--border)] bg-[rgba(255,255,255,0.48)] px-3 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {items.map((item, index) => {
           const selected = activeTab === item.value;
@@ -70,7 +70,7 @@ export function DocsTabs({ items, defaultValue }: DocsTabsProps) {
               aria-controls={panelId}
               onClick={() => setActiveTab(item.value)}
               onKeyDown={(event) => handleKeyDown(event, index)}
-              className={`rounded-full border px-4 py-2 text-sm transition ${
+              className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition ${
                 selected
                   ? "border-[var(--border-brand)] bg-white text-[var(--foreground)] shadow-[0_8px_20px_rgba(36,29,21,0.06)]"
                   : "border-transparent text-[var(--foreground-secondary)] hover:border-[var(--border)] hover:bg-white/70 hover:text-[var(--foreground)]"

--- a/frontend/components/docs-toc.tsx
+++ b/frontend/components/docs-toc.tsx
@@ -27,6 +27,7 @@ export function DocsToc({
   actions = [],
 }: DocsTocProps) {
   const [activeId, setActiveId] = useState<string>(() => items[0]?.id ?? "");
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
     if (items.length === 0) {
@@ -61,42 +62,134 @@ export function DocsToc({
   }
 
   return (
-    <div className="sticky top-20 rounded-[24px] border border-[var(--border)] bg-[rgba(255,252,247,0.76)] p-4 shadow-[0_18px_40px_rgba(36,29,21,0.06)] backdrop-blur-xl">
-      <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]">
-        {title}
-      </p>
-      <p className="mt-2 text-sm leading-6 text-[var(--foreground-secondary)]">{subtitle}</p>
-      {actions.length > 0 ? (
-        <div className="mt-4 space-y-2 border-b border-[var(--border)] pb-4">
-          {actions.map((action) => (
-            <a
-              key={action.href}
-              href={action.href}
-              className="block rounded-[14px] border border-[var(--border)] bg-[var(--background-elevated)] px-3 py-2.5 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:bg-white hover:text-[var(--foreground)]"
-            >
-              {action.label}
-            </a>
-          ))}
+    <>
+      <div className="hidden lg:block">
+        <div className="sticky top-20 rounded-[24px] border border-[var(--border)] bg-[rgba(255,252,247,0.76)] p-4 shadow-[0_18px_40px_rgba(36,29,21,0.06)] backdrop-blur-xl">
+          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]">
+            {title}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[var(--foreground-secondary)]">{subtitle}</p>
+          {actions.length > 0 ? (
+            <div className="mt-4 space-y-2 border-b border-[var(--border)] pb-4">
+              {actions.map((action) => (
+                <a
+                  key={action.href}
+                  href={action.href}
+                  className="block rounded-[14px] border border-[var(--border)] bg-[var(--background-elevated)] px-3 py-2.5 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:bg-white hover:text-[var(--foreground)]"
+                >
+                  {action.label}
+                </a>
+              ))}
+            </div>
+          ) : null}
+          <ul className="mt-4 space-y-1.5">
+            {items.map((item) => (
+              <li key={item.id}>
+                <a
+                  href={`#${item.id}`}
+                  aria-current={activeId === item.id ? "location" : undefined}
+                  className={`block rounded-[14px] border-l-2 px-3 py-2 text-sm transition ${
+                    activeId === item.id
+                      ? "border-l-[var(--brand-bright)] bg-[var(--brand-subtle)] text-[var(--foreground)]"
+                      : "border-l-transparent text-[var(--foreground-secondary)] hover:bg-white/70 hover:text-[var(--foreground)]"
+                  }`}
+                  style={{ paddingLeft: `${item.level === 1 ? 12 : 20}px` }}
+                >
+                  {item.text}
+                </a>
+              </li>
+            ))}
+          </ul>
         </div>
-      ) : null}
-      <ul className="mt-4 space-y-1.5">
-        {items.map((item) => (
-          <li key={item.id}>
-            <a
-              href={`#${item.id}`}
-              aria-current={activeId === item.id ? "location" : undefined}
-              className={`block rounded-[14px] border-l-2 px-3 py-2 text-sm transition ${
-                activeId === item.id
-                  ? "border-l-[var(--brand-bright)] bg-[var(--brand-subtle)] text-[var(--foreground)]"
-                  : "border-l-transparent text-[var(--foreground-secondary)] hover:bg-white/70 hover:text-[var(--foreground)]"
-              }`}
-              style={{ paddingLeft: `${item.level === 1 ? 12 : 20}px` }}
-            >
-              {item.text}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </div>
+      </div>
+
+      <div className="lg:hidden">
+        <button
+          type="button"
+          onClick={() => setMobileOpen(true)}
+          className="fixed bottom-4 right-4 z-[115] inline-flex items-center gap-2 rounded-full border border-[var(--border-brand)] bg-[rgba(255,252,247,0.96)] px-4 py-3 text-sm font-medium text-[var(--foreground)] shadow-[0_20px_50px_rgba(36,29,21,0.16)] backdrop-blur-xl"
+        >
+          <span>{title}</span>
+          <span className="rounded-full bg-[var(--brand-subtle)] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--brand-bright)]">
+            {items.length}
+          </span>
+        </button>
+
+        {mobileOpen ? (
+          <div className="fixed inset-0 z-[125]">
+            <button
+              type="button"
+              aria-label="Close table of contents"
+              onClick={() => setMobileOpen(false)}
+              className="absolute inset-0 bg-[rgba(36,29,21,0.32)] backdrop-blur-sm"
+            />
+
+            <div className="absolute inset-x-0 bottom-0 max-h-[78vh] overflow-y-auto rounded-t-[28px] border-t border-[var(--border)] bg-[rgba(255,252,247,0.98)] px-5 py-5 shadow-[0_-18px_48px_rgba(36,29,21,0.16)]">
+              <div className="flex items-start justify-between gap-4 border-b border-[var(--border)] pb-4">
+                <div>
+                  <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--brand-bright)]">
+                    {title}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--foreground-secondary)]">
+                    {subtitle}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  aria-label="Close table of contents"
+                  onClick={() => setMobileOpen(false)}
+                  className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-white/80 text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+                >
+                  <CloseIcon />
+                </button>
+              </div>
+
+              {actions.length > 0 ? (
+                <div className="mt-4 space-y-2 border-b border-[var(--border)] pb-4">
+                  {actions.map((action) => (
+                    <a
+                      key={action.href}
+                      href={action.href}
+                      onClick={() => setMobileOpen(false)}
+                      className="block rounded-[14px] border border-[var(--border)] bg-[var(--background-elevated)] px-3 py-2.5 text-sm text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:bg-white hover:text-[var(--foreground)]"
+                    >
+                      {action.label}
+                    </a>
+                  ))}
+                </div>
+              ) : null}
+
+              <ul className="mt-4 space-y-1.5">
+                {items.map((item) => (
+                  <li key={item.id}>
+                    <a
+                      href={`#${item.id}`}
+                      aria-current={activeId === item.id ? "location" : undefined}
+                      onClick={() => setMobileOpen(false)}
+                      className={`block rounded-[14px] border-l-2 px-3 py-2 text-sm transition ${
+                        activeId === item.id
+                          ? "border-l-[var(--brand-bright)] bg-[var(--brand-subtle)] text-[var(--foreground)]"
+                          : "border-l-transparent text-[var(--foreground-secondary)] hover:bg-white/70 hover:text-[var(--foreground)]"
+                      }`}
+                      style={{ paddingLeft: `${item.level === 1 ? 12 : 20}px` }}
+                    >
+                      {item.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M6 6l12 12M18 6 6 18" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+    </svg>
   );
 }

--- a/frontend/components/site-header-auth-actions.tsx
+++ b/frontend/components/site-header-auth-actions.tsx
@@ -106,7 +106,7 @@ export function SiteHeaderAuthActions({
   const showSignOutButton = sessionState === "authenticated" && !isConsoleRoute;
 
   if (sessionState === "loading") {
-    return <div className="h-10 w-[232px]" aria-hidden="true" />;
+    return <div className="h-10 w-[112px] sm:w-[232px]" aria-hidden="true" />;
   }
 
   if (isConsoleRoute && sessionState !== "authenticated") {
@@ -118,13 +118,13 @@ export function SiteHeaderAuthActions({
       <>
         <Link
           href={buildAuthPageHref("/login", currentPath) as Route}
-          className="button-secondary focus-ring"
+          className="focus-ring rounded-full px-3 py-2 text-sm text-[var(--foreground-secondary)] transition hover:bg-white/40 hover:text-[var(--foreground)] sm:border sm:border-[var(--border)] sm:bg-white/70 sm:px-4 sm:font-medium sm:hover:border-[var(--border-strong)] sm:hover:bg-white"
         >
           Sign in
         </Link>
         <Link
           href={buildAuthPageHref("/signup", currentPath) as Route}
-          className="button-primary focus-ring min-w-[112px]"
+          className="button-primary focus-ring min-w-0 px-4 sm:min-w-[112px]"
         >
           Sign up
         </Link>
@@ -150,7 +150,7 @@ export function SiteHeaderAuthActions({
       {showSignOutButton ? (
         <button
           type="button"
-          className="button-primary focus-ring min-w-[112px]"
+          className="button-primary focus-ring min-w-0 px-4 sm:min-w-[112px]"
           disabled={isSubmitting}
           onClick={() => void handleSignOut()}
         >

--- a/frontend/components/site-header.tsx
+++ b/frontend/components/site-header.tsx
@@ -12,9 +12,9 @@ export function SiteHeader({ currentPath }: SiteHeaderProps) {
 
   return (
     <header className="sticky top-4 z-50 mx-auto max-w-[1400px]">
-      <div className="surface-elevated flex items-center justify-between rounded-full px-2 py-2 pr-4 lg:pr-6 backdrop-blur-xl">
+      <div className="surface-elevated flex items-center justify-between gap-3 rounded-[28px] px-3 py-3 sm:rounded-full sm:px-2 sm:py-2 sm:pr-4 lg:pr-6 backdrop-blur-xl">
         {/* Logo */}
-        <div className="flex items-center pl-4 lg:pl-6">
+        <div className="min-w-0 flex items-center pl-2 sm:pl-4 lg:pl-6">
           <BrandMark />
         </div>
 
@@ -43,7 +43,18 @@ export function SiteHeader({ currentPath }: SiteHeaderProps) {
         </nav>
 
         {/* Actions */}
-        <div className="flex items-center gap-2 lg:gap-3">
+        <div className="flex shrink-0 items-center gap-2 lg:gap-3">
+          <a
+            href="https://github.com/cerul-ai/cerul"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open Cerul on GitHub"
+            className="focus-ring inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-white/70 text-[var(--foreground-secondary)] transition hover:border-[var(--border-strong)] hover:bg-white hover:text-[var(--foreground)] lg:hidden"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.765-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3-.405 1.02.005 2.047.138 3.006.404 2.295-1.56 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.23 1.905 1.23 3.225 0 4.609-2.807 5.625-5.475 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+            </svg>
+          </a>
           <a
             href="https://github.com/cerul-ai/cerul"
             target="_blank"
@@ -60,7 +71,7 @@ export function SiteHeader({ currentPath }: SiteHeaderProps) {
       </div>
 
       {/* Mobile navigation */}
-      <nav className="mt-3 flex items-center justify-center gap-1 rounded-full bg-[var(--surface)] p-1 backdrop-blur-xl lg:hidden">
+      <nav className="mt-3 flex items-center justify-start gap-1 overflow-x-auto rounded-full bg-[var(--surface)] p-1 backdrop-blur-xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden lg:hidden">
         {visibleNavigation.map((item) => {
           const isActive = isPrimaryNavigationActive(currentPath, item.href);
 


### PR DESCRIPTION
## Summary
- improve mobile navigation and layout behavior across the public pages, docs pages, dashboard shell, and admin shell
- make docs navigation, tabs, TOC, and code blocks behave better on narrow screens without changing desktop structure
- remove the large bottom whitespace regression caused by scroll-triggered reveal animations by switching shared motion wrappers to mount-triggered behavior
- add `MOBILE_RESPONSIVE_FIXES.md` to document the audit findings, root causes, and follow-up guidance

## Affected directories
- `frontend/app`
- `frontend/components`
- `MOBILE_RESPONSIVE_FIXES.md`

## Config changes
- no new committed environment variables or config files
- local verification used temporary local env overrides only for browser login/testing and did not change repository config

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend build`
- local browser verification across public pages and authenticated dashboard/admin shells on mobile and desktop viewports

## Known out-of-scope issue
- some dashboard/admin data endpoints still return `502` in the local environment; this PR keeps the shell/layout fixes and does not change backend proxy or data behavior

## Screenshots
- local screenshots were generated during Playwright verification and kept outside the public repository workspace because this repository is public-safe
