### PR TITLE
feat: add Desktop App (app.cerul.ai) entry to footer

### DIFF
--- a/frontend/components/site-footer.tsx
+++ b/frontend/components/site-footer.tsx
@@ -9,6 +9,7 @@ export function SiteFooter() {
       title: "Product",
       links: [
         { label: "Search API", href: "/docs" },
+        { label: "Desktop App", href: "https://app.cerul.ai" },
         { label: "Pricing", href: "/pricing" },
         { label: "Dashboard", href: "/dashboard" },
       ],


### PR DESCRIPTION
Adds a **Desktop App** link to the footer Product column pointing to **app.cerul.ai** — a discoverable entry point from cerul.ai to the new local-first desktop app.

Minimal and reversible: the footer already renders external links with proper `target`/`rel`. A top-nav entry can be added later if you want more prominence.

> The app.cerul.ai site goes live once it's deployed (Cloudflare Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
