### PR TITLE
Adopt new brand slogans (where video becomes citable / stop scrubbing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
     <img src="./assets/logo.png" alt="Cerul" width="80" />
   </a>
   <h1>Cerul</h1>
-  <p><strong>The video search layer for AI agents.</strong></p>
-  <p>Teach your AI agents to see. Search video by meaning — across speech, visuals, and on-screen text.</p>
+  <p><strong>Where video becomes citable.</strong></p>
+  <p>Stop scrubbing. Start searching. Search video by meaning — across speech, visuals, and on-screen text.</p>
 
   <p>
     <a href="https://cerul.ai/docs"><strong>Docs</strong></a> &middot;

--- a/frontend/app/brand/page.tsx
+++ b/frontend/app/brand/page.tsx
@@ -186,7 +186,7 @@ export default function BrandPage() {
                   One-liner
                 </h2>
                 <p className="mt-4 text-lg leading-relaxed text-[var(--foreground)]">
-                  Cerul is the video search layer for AI agents — search video
+                  Cerul is where video becomes citable — search video
                   by meaning across speech, visuals, and on-screen text.
                 </p>
               </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -80,7 +80,7 @@ export const metadata: Metadata = {
     template: "%s | Cerul",
   },
   description:
-    "Cerul — the video search layer for AI agents. Search video by meaning — across speech, visuals, and on-screen text.",
+    "Cerul — where video becomes citable. Search video by meaning — across speech, visuals, and on-screen text.",
   icons: {
     icon: [
       { url: "/logo.svg", type: "image/svg+xml" },
@@ -96,7 +96,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Cerul",
     description:
-      "Cerul — the video search layer for AI agents. Search video by meaning — across speech, visuals, and on-screen text.",
+      "Cerul — where video becomes citable. Search video by meaning — across speech, visuals, and on-screen text.",
     url: siteOrigin,
     siteName: "Cerul",
     type: "website",
@@ -106,7 +106,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Cerul",
     description:
-      "Cerul — the video search layer for AI agents. Search video by meaning — across speech, visuals, and on-screen text.",
+      "Cerul — where video becomes citable. Search video by meaning — across speech, visuals, and on-screen text.",
     images: defaultTwitterImages,
   },
 };

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -76,7 +76,7 @@ const jsonLd = {
       "@type": "WebAPI",
       name: "Cerul Search API",
       description:
-        "The video search layer for AI agents. Search video by meaning — across speech, visuals, and on-screen text.",
+        "Where video becomes citable. Search video by meaning — across speech, visuals, and on-screen text.",
       documentation: `${siteOrigin}/docs`,
       url: siteOrigin,
       provider: {
@@ -169,14 +169,14 @@ export default async function HomePage() {
                 <BlurFade delay={100}>
                   <span className="eyebrow inline-flex items-center gap-2 rounded-full border border-[var(--border-brand)] bg-[var(--brand-subtle)] px-4 py-1.5 text-xs font-semibold uppercase tracking-wider text-[var(--brand-bright)]">
                     <span className="h-1.5 w-1.5 rounded-full bg-[var(--brand)] animate-pulse" />
-                    The video search layer for AI agents
+                    Where video becomes citable
                   </span>
                 </BlurFade>
 
                 <BlurFade delay={200}>
                   <h1 className="mt-8 text-4xl font-bold leading-[1.1] tracking-tight text-[var(--foreground)] sm:text-5xl lg:text-7xl">
-                    Teach your AI agents{" "}
-                    <TextGradient animate>to see</TextGradient>
+                    Stop scrubbing.{" "}
+                    <TextGradient animate>Start searching.</TextGradient>
                   </h1>
                 </BlurFade>
 
@@ -303,7 +303,7 @@ export default async function HomePage() {
             {/* Features Section */}
             <Features
               eyebrow="Features"
-              title="Teach your AI agents to see"
+              title="Every second, searchable"
               description="Search video by meaning — across speech, visuals, and on-screen text."
               features={features}
             />

--- a/frontend/components/site-footer.tsx
+++ b/frontend/components/site-footer.tsx
@@ -45,7 +45,7 @@ export function SiteFooter() {
           <div className="space-y-6">
             <BrandMark />
             <p className="max-w-sm text-[15px] leading-relaxed text-[var(--foreground-secondary)]">
-              The video search layer for AI agents. Search video by meaning
+              Where video becomes citable. Search video by meaning
               — across speech, visuals, and on-screen text.
             </p>
             <div className="flex items-center gap-4">

--- a/frontend/lib/email-templates.ts
+++ b/frontend/lib/email-templates.ts
@@ -142,7 +142,7 @@ function renderEmailTemplate(input: EmailTemplateInput): string {
         </div>
 
         <p style="margin:18px 0 0;padding:0 10px;color:${palette.textSecondary};font-size:12px;line-height:1.7;text-align:center;">
-          Cerul — The video search layer for AI agents
+          Cerul — where video becomes citable
         </p>
       </div>
     </div>
@@ -162,7 +162,7 @@ export function emailVerificationTemplate(params: {
     title: "Verify your email address",
     intro: `Hi ${name}, thanks for signing up to Cerul.`,
     body: [
-      "Click below to verify your email and start using the video search layer built for AI agents.",
+      "Click below to verify your email and start searching your video by meaning.",
     ],
     cta: {
       href: params.url,

--- a/frontend/lib/social-metadata.ts
+++ b/frontend/lib/social-metadata.ts
@@ -1,7 +1,7 @@
 export const SOCIAL_IMAGE_VERSION = "20260314";
 export const HOME_SOCIAL_IMAGE_VERSION = "20260315-home1";
 
-const socialImageAlt = "Cerul — Teach your AI agents to see";
+const socialImageAlt = "Cerul — where video becomes citable";
 
 function createOpenGraphImages(version: string) {
   return [

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,6 +1,6 @@
 # Cerul
 
-> Cerul is the video search layer for AI agents. Search video by meaning — across speech, visuals, and on-screen text.
+> Cerul is where video becomes citable. Search video by meaning — across speech, visuals, and on-screen text.
 
 ## About
 

--- a/frontend/public/press-kit/06-brand-guidelines/company-info.md
+++ b/frontend/public/press-kit/06-brand-guidelines/company-info.md
@@ -1,7 +1,7 @@
 # Cerul — Company Info & Boilerplate
 
 ## One-liner
-> Cerul is the video search layer for AI agents — search video by meaning across speech, visuals, and on-screen text.
+> Cerul is where video becomes citable — search video by meaning across speech, visuals, and on-screen text.
 
 ## Short description (≤280 chars)
 > Cerul gives AI agents a Search API for video. Query by meaning and get back the exact moments across speech, visuals, and on-screen text — from tech talks, podcasts, conferences, and earnings calls.

--- a/frontend/public/press-kit/README.md
+++ b/frontend/public/press-kit/README.md
@@ -10,7 +10,7 @@ PNG at a specific size, dark-mode screenshot, founder headshot), email
 
 ## What is Cerul?
 
-**Cerul is the video search layer for AI agents.** It lets agents and
+**Cerul: where video becomes citable.** It lets agents and
 developers search video by meaning — across speech, visuals, and on-screen
 text — through a single API.
 


### PR DESCRIPTION
Replaces retired slogans sitewide per 2026-07-07 brand decision:

- **Identity**: `Cerul: where video becomes citable.` — footer, meta/OG descriptions, llms.txt, press kit boilerplate, brand page, transactional email footer
- **Action**: `Stop scrubbing. Start searching.` — hero H1, README
- Retired: "The video search layer for AI agents", "Teach your AI agents to see"
- Kept: functional subline "Search video by meaning — across speech, visuals, and on-screen text."

🤖 Generated with [Claude Code](https://claude.com/claude-code)