### PR TITLE
Finalize canonical brand copy + BRAND.md

### DIFF
--- a/BRAND.md
+++ b/BRAND.md
@@ -1,0 +1,53 @@
+# Cerul Brand Copy — Canonical Reference
+
+> Single source of truth for all public-facing slogans and descriptions.
+> Locked 2026-07-07. Do not invent new variants — reuse these verbatim.
+
+## Two slogans (the ONLY two)
+
+**Identity** — use where readers are *learning who we are*
+(deck cover, site footer, GitHub/repo descriptions, About page, splash, bio, press boilerplate):
+
+- EN: **Cerul: where video becomes citable.**
+- ZH: **Cerul：让视频有出处**
+
+**Action** — use where readers are *being persuaded*
+(site hero H1, ads, App Store subtitle, in-app home heading, tweet closers, merch):
+
+- EN: **Stop scrubbing. Start searching.**
+- ZH: **别拖进度条了，直接搜**
+
+## Two product descriptions (pick by product, follows the slogan)
+
+**API / platform** — cerul.ai, SDK/CLI READMEs, developer docs, plugin marketplace:
+
+- EN: **The video search API for agents — meaning-based, grounded, timestamped.**
+- ZH: **给 agent 的视频搜索 API——按语义、有出处、带时间码。**
+
+**App** — app.cerul.ai, App Store, in-app onboarding, cerul-app README:
+
+- EN: **Ask anything about what you've watched and heard — get the exact second.**
+- ZH: **关于你看过、听过的，问一句就有答案——精确到那一秒。**
+
+## Assembly rules
+
+- Full intro = identity slogan **+** the matching product description, concatenated verbatim, not rewritten.
+  e.g. footer: `Cerul: where video becomes citable. The video search API for agents — meaning-based, grounded, timestamped.`
+- **Max one slogan per screen.** Descriptions, buttons, FAQ are normal UI copy, unrestricted.
+- Hero lede may be longer, but only *expand* concepts already in the description — never invent new value phrases.
+- **Never expose "index / 索引"** in user-facing copy (it's implementation). Express local-first as "on your own machine / 全在本机".
+- Repo description formula: `Cerul — where video becomes citable. <one noun phrase>` (CLI / TypeScript SDK / …). Don't cram a description sentence in.
+
+## SEO / GEO keywords (canonical set)
+
+video search API, search video by meaning, video RAG, timestamped video citations,
+grounded video search, ask your videos, search podcasts and videos, video evidence for AI agents,
+local-first video search, cite video, semantic video search.
+(中文：视频搜索 API、按语义搜视频、视频引用、带时间码的检索、给 agent 的视频搜索、本地视频搜索。)
+
+## Retired — never use again
+
+- 视听第二大脑 / A second brain for video & audio
+- The video search layer for AI agents
+- Teach your AI agents to see
+- 找到视频里说过的每一句话 / Find every word said in your videos

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </a>
   <h1>Cerul</h1>
   <p><strong>Where video becomes citable.</strong></p>
-  <p>Stop scrubbing. Start searching. One API to search video like text — every word, every frame, timestamped.</p>
+  <p>Stop scrubbing. Start searching. The video search API for agents — meaning-based, grounded, timestamped.</p>
 
   <p>
     <a href="https://cerul.ai/docs"><strong>Docs</strong></a> &middot;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -80,7 +80,7 @@ export const metadata: Metadata = {
     template: "%s | Cerul",
   },
   description:
-    "Cerul — where video becomes citable. One API to search video like text — every word, every frame, timestamped.",
+    "Cerul — where video becomes citable. The video search API for agents — meaning-based, grounded, timestamped.",
   icons: {
     icon: [
       { url: "/logo.svg", type: "image/svg+xml" },
@@ -96,7 +96,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Cerul",
     description:
-      "Cerul — where video becomes citable. One API to search video like text — every word, every frame, timestamped.",
+      "Cerul — where video becomes citable. The video search API for agents — meaning-based, grounded, timestamped.",
     url: siteOrigin,
     siteName: "Cerul",
     type: "website",
@@ -106,7 +106,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Cerul",
     description:
-      "Cerul — where video becomes citable. One API to search video like text — every word, every frame, timestamped.",
+      "Cerul — where video becomes citable. The video search API for agents — meaning-based, grounded, timestamped.",
     images: defaultTwitterImages,
   },
 };

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -76,7 +76,7 @@ const jsonLd = {
       "@type": "WebAPI",
       name: "Cerul Search API",
       description:
-        "Where video becomes citable. One API to search video like text — every word, every frame, timestamped.",
+        "Where video becomes citable. The video search API for agents — meaning-based, grounded, timestamped.",
       documentation: `${siteOrigin}/docs`,
       url: siteOrigin,
       provider: {
@@ -182,7 +182,7 @@ export default async function HomePage() {
 
                 <BlurFade delay={300}>
                   <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-[var(--foreground-secondary)] sm:text-xl">
-                    One API to search video like text — every word, every frame,
+                    The video search API for agents — meaning-based, grounded,
                     timestamped.
                   </p>
                 </BlurFade>
@@ -304,7 +304,7 @@ export default async function HomePage() {
             <Features
               eyebrow="Features"
               title="Every second, searchable"
-              description="One API to search video like text — every word, every frame, timestamped."
+              description="The video search API for agents — meaning-based, grounded, timestamped."
               features={features}
             />
 

--- a/frontend/components/site-footer.tsx
+++ b/frontend/components/site-footer.tsx
@@ -45,8 +45,8 @@ export function SiteFooter() {
           <div className="space-y-6">
             <BrandMark />
             <p className="max-w-sm text-[15px] leading-relaxed text-[var(--foreground-secondary)]">
-              Where video becomes citable. One API to search video like
-              text — every word, every frame, timestamped.
+              Where video becomes citable. The video search API for agents —
+              meaning-based, grounded, timestamped.
             </p>
             <div className="flex items-center gap-4">
               <a

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,6 +1,6 @@
 # Cerul
 
-> Cerul is where video becomes citable. One API to search video like text — every word, every frame, timestamped.
+> Cerul is where video becomes citable. The video search API for agents — meaning-based, grounded, timestamped.
 
 ## About
 

--- a/frontend/public/press-kit/06-brand-guidelines/company-info.md
+++ b/frontend/public/press-kit/06-brand-guidelines/company-info.md
@@ -1,7 +1,7 @@
 # Cerul — Company Info & Boilerplate
 
 ## One-liner
-> Cerul is where video becomes citable — one API to search video like text: every word, every frame, timestamped.
+> Cerul is where video becomes citable — the video search API for agents: meaning-based, grounded, timestamped.
 
 ## Short description (≤280 chars)
 > Cerul gives AI agents a Search API for video. Query by meaning and get back the exact moments across speech, visuals, and on-screen text — from tech talks, podcasts, conferences, and earnings calls.


### PR DESCRIPTION
Replaces the temporary 'One API to search video like text…' with the locked API description **The video search API for agents — meaning-based, grounded, timestamped** everywhere (incl. JSON-LD WebAPI schema), and adds BRAND.md as the single source of truth with SEO/GEO keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)