### PR TITLE
chore(deps): ignore typescript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
       - dependency-name: "eslint"
         update-types:
           - "version-update:semver-major"
+      # typescript-eslint does not support TypeScript 7 yet; lint/build fail on TS major bumps
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     groups:
       next-ecosystem:
         patterns:


### PR DESCRIPTION
TypeScript 7 breaks typescript-eslint (`Cannot read properties of undefined (reading 'Cjs')`) — Frontend Lint and Build fail on dependabot PR #218. Ignore TS major bumps like we already do for eslint, until the lint toolchain supports TS 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)